### PR TITLE
Prevent referrer from being send

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="no-referrer">
 
     {{content-for 'head'}}
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,7 +19,8 @@ module.exports = function(environment) {
       'connect-src': "'self'",
       'img-src': "'self'",
       'style-src': "'self'",
-      'media-src': "'self'"
+      'media-src': "'self'",
+      'referrer': "no-referrer"
     },
 
     EmberENV: {

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,5 +1,5 @@
 # Content Security Policy-Headers
 # you have to enable apache module headers to get them working
-#Header set Content-Security-Policy "default-src 'self'; referrer no-referrer;"
-#Header set X-Content-Security-Policy "default-src 'self'; referrer no-referrer;"
-#Header set X-Webkit-CSP "default-src 'self'; referrer no-referrer;"
+#Header set Content-Security-Policy "default-src 'self'; referrer no-referrer; object-src 'none'; frame-anchors 'none';"
+#Header set X-Content-Security-Policy "default-src 'self'; referrer no-referrer; object-src 'none'; frame-anchors 'none';"
+#Header set X-Webkit-CSP "default-src 'self'; referrer no-referrer; object-src 'none'; frame-anchors 'none';"

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,5 +1,5 @@
 # Content Security Policy-Headers
 # you have to enable apache module headers to get them working
-#Header set Content-Security-Policy "default-src 'self'; referrer no-referrer; object-src 'none'; frame-anchors 'none';"
-#Header set X-Content-Security-Policy "default-src 'self'; referrer no-referrer; object-src 'none'; frame-anchors 'none';"
-#Header set X-Webkit-CSP "default-src 'self'; referrer no-referrer; object-src 'none'; frame-anchors 'none';"
+#Header set Content-Security-Policy "default-src 'none'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; referrer no-referrer;"
+#Header set X-Content-Security-Policy "default-src 'none'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; referrer no-referrer;"
+#Header set X-Webkit-CSP "default-src 'none'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; referrer no-referrer;"

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,5 +1,5 @@
 # Content Security Policy-Headers
 # you have to enable apache module headers to get them working
-#Header set Content-Security-Policy "default-src 'self';"
-#Header set X-Content-Security-Policy "default-src 'self';"
-#Header set X-Webkit-CSP "default-src 'self';"
+#Header set Content-Security-Policy "default-src 'self'; referrer no-referrer;"
+#Header set X-Content-Security-Policy "default-src 'self'; referrer no-referrer;"
+#Header set X-Webkit-CSP "default-src 'self'; referrer no-referrer;"


### PR DESCRIPTION
This uses the CSP, which is quite widespread. For more security (as some admins may not enable the htaccess) you may additionally use the "Referrer-Policy" meta tag/header as tracked in https://github.com/jelhan/croodle/issues/113.

Just FYI: Also the [CSP](https://content-security-policy.com/) can be declared in the HTML code although it is somehow limited in this case.