### PR TITLE
deps: upgrade ember-page-title

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{head-layout}}
+
 {{title "Croodle"}}
 
 <div class="container">

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,6 @@
+{{!--
+Add content you wish automatically added to the documents head
+here. The 'model' available in this template can be populated by
+setting values on the 'head-data' service.
+--}}
+<title>{{model.title}}</title>

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-math-helpers": "^2.8.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-moment": "^7.8.0",
-    "ember-page-title": "^3.0.6",
+    "ember-page-title": "^5.0.0",
     "ember-radio-buttons": "^4.0.1",
     "ember-resolver": "^5.0.1",
     "ember-route-action-helper": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,7 +3949,7 @@ ember-cli-app-version@^3.2.0:
     ember-cli-babel "^6.12.0"
     git-repo-version "^1.0.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -4121,13 +4121,13 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
-ember-cli-head@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-head/-/ember-cli-head-0.3.1.tgz#a407df4880f235280371c437bb5b0b5cbdaea646"
-  integrity sha1-pAffSIDyNSgDccQ3u1sLXL2upkY=
+ember-cli-head@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-head/-/ember-cli-head-0.4.1.tgz#28b7ee86439746640834b232a3b34ab1329f3cf3"
+  integrity sha512-MIgshw5nGil7Q/TU4SDRCsgsiA3wPC9WqOig/g1LlHTNXjR4vH7s/ddG7GTfK5Kt4ZQHJEUDXpd/lIbdBkIQ/Q==
   dependencies:
-    ember-cli-babel "^6.1.0"
-    ember-cli-htmlbars "^2.0.1"
+    ember-cli-babel "^6.11.0"
+    ember-cli-htmlbars "^2.0.3"
 
 ember-cli-htmlbars-inline-precompile@^1.0.0, ember-cli-htmlbars-inline-precompile@^1.0.3:
   version "1.0.5"
@@ -4511,7 +4511,7 @@ ember-concurrency@^0.8.7:
     ember-cli-babel "^6.8.2"
     ember-maybe-import-regenerator "^0.1.5"
 
-ember-copy@1.0.0:
+ember-copy@1.0.0, ember-copy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
   integrity sha512-aiZNAvOmdemHdvZNn0b5b/0d9g3JFpcOsrDgfhYEbfd7SzE0b69YiaVK2y3wjqfjuuiA54vOllGN4pjSzECNSw==
@@ -4728,14 +4728,15 @@ ember-native-dom-helpers@^0.5.3:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
-ember-page-title@^3.0.6:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/ember-page-title/-/ember-page-title-3.2.2.tgz#241effbc8228ecfb75e33540f6707003fdf6db31"
-  integrity sha1-JB7/vIIo7Pt14zVA9nBwA/322zE=
+ember-page-title@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-page-title/-/ember-page-title-5.0.0.tgz#6de61ecfd0278246c2f57ab29f3affd208e0459d"
+  integrity sha512-BQ3/yeKUWQejieZdnnR/lo51n8GYuqzEHrok3nw9nAkOCp81kJTf47EAUjp/ZbDJeWfm1uTfsXVacjwaNW9GHQ==
   dependencies:
-    ember-cli-babel "^6.0.0"
-    ember-cli-head "^0.3.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-head "^0.4.0"
     ember-cli-htmlbars "^2.0.1"
+    ember-copy "^1.0.0"
 
 ember-popper@^0.9.0:
   version "0.9.2"


### PR DESCRIPTION
Current page title is put before generic one, e.g. "Create a poll | Croodle"
instead of "Croodle | Create a poll". This was an upstream change with
could reasoning. Have a look here:
https://github.com/adopted-ember-addons/ember-page-title/releases/tag/5.0.0

Version 4.0.0 required the `{{head-layout}}` component in application's
template:
https://github.com/adopted-ember-addons/ember-page-title/releases/tag/4.0.0