### PR TITLE
deps: only include required components of Ember Boostrap in build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,8 @@ module.exports = function(defaults) {
     'ember-bootstrap': {
       importBootstrapCSS: false,
       'bootstrapVersion': 3,
-      'importBootstrapFont': true
+      'importBootstrapFont': true,
+      whitelist: ['bs-alert', 'bs-button', 'bs-button-group', 'bs-form', 'bs-modal'],
     },
     'ember-cli-babel': {
       includePolyfill: true


### PR DESCRIPTION
This reduced the vendor.js size from 1.54 MB (395.39 KB gzipped) to 1.48 MB (385.52 KB gzipped).