### PR TITLE
dep ember-export-application-global is not needed anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "ember-cp-validations": "^3.5.0",
     "ember-data": "~3.4.0",
     "ember-data-model-fragments": "^3.3.0",
-    "ember-export-application-global": "^2.0.0",
     "ember-i18n": "^5.0.2",
     "ember-i18n-cp-validations": "^3.0.2",
     "ember-load-initializers": "^1.1.0",


### PR DESCRIPTION
It's most likely a leftover from upgrading ember a long time ago.