### PR TITLE
remove dead code from build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -21,7 +21,10 @@ module.exports = function(defaults) {
     },
     'ember-composable-helpers': {
       only: ['array', 'object-at'],
-    }
+    },
+    'ember-math-helpers': {
+      only: ['gt', 'lte', 'sub'],
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@ember/optional-features": "^0.6.3",
     "bootstrap-sass": "^3.3.7",
     "ember-ajax": "^4.0.0",
-    "ember-array-helper": "^5.0.0",
     "ember-awesome-macros": "^3.1.0",
     "ember-bootstrap": "^2.1.2",
     "ember-bootstrap-cp-validations": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3500,13 +3500,6 @@ ember-ajax@^4.0.0:
     ember-cli-babel "^6.16.0"
     najax "^1.0.3"
 
-ember-array-helper@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ember-array-helper/-/ember-array-helper-5.0.0.tgz#d2d72f170e15d120bdaffe456d5cdfd8d335de75"
-  integrity sha512-TkmHoOgPmv4QOs8Z/DPA80kas8m8yl3aeuxC1Ph40V3byFEq1A4Z/JNnUNkfRYmWiYveBc996NV/y2wwK/2ptw==
-  dependencies:
-    ember-cli-babel "^7.1.2"
-
 ember-assign-helper@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ember-assign-helper/-/ember-assign-helper-0.2.0.tgz#02d1b5ee6b4f9cb68036b7d19db47f2a9d74f148"
@@ -3581,7 +3574,7 @@ ember-cli-app-version@^3.2.0:
     ember-cli-babel "^6.12.0"
     git-repo-version "^1.0.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -3619,7 +3612,7 @@ ember-cli-babel@^6.8.1:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.2.0:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.2.0.tgz#5c5bd877fb73f6fb198c878d3127ba9e18e9b8a0"
   integrity sha512-vwx/AgPD7P4ebgTFJMqFovbrSNCA02UMuItlR/Il16njYjgN9ZzjUqgYxaylN7k8RF88wdJq3jrtqyMS/oOq8A==
@@ -4239,13 +4232,6 @@ ember-debug-handlers-polyfill@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.1.tgz#e9ae0a720271a834221179202367421b580002ef"
   integrity sha512-lO7FBAqJjzbL+IjnWhVfQITypPOJmXdZngZR/Vdn513W4g/Q6Sjicao/mDzeDCb48Y70C4Facwk0LjdIpSZkRg==
-
-ember-export-application-global@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
-  integrity sha1-jW12GayKGj+MQwA1Sesh6+1oW9I=
-  dependencies:
-    ember-cli-babel "^6.0.0-beta.7"
 
 ember-factory-for-polyfill@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
- Cherry-picks needed helpers from ember-math-helpers.
- Removes ember-array-helper, which isn't in use cause `array` helper is provided by ember-composable-helpers.

Reduces build size by ~20 KB (1.2 KB gzipped).

ember-truth-helpers does not provide any way to cherry-pick helpers from it. :disappointed: 