### PR TITLE
fix: test must not trigger confirmation in IE 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,9 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
   # test against different browsers using sauce lab
-  - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi
+  - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js --launch BS_IE_11; fi
+  - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js --launch BS_MS_EDGE; fi
+  - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js --launch BS_SAFARI_CURRENT; fi
   # run api tests with composer
   - if [ $TEST = "API" ]; then cd api/ && ./vendor/bin/codecept run && cd ..; fi
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-browser-navigation-button-test-helper": "^0.1.1",
     "ember-cli-browserstack": "^0.0.7",
     "ember-cli-chart": "^3.3.1",
-    "ember-cli-clipboard": "^0.8.0",
+    "ember-cli-clipboard": "^0.11.1",
     "ember-cli-content-security-policy": "^1.0.0",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-deprecation-workflow": "^0.2.3",

--- a/tests/acceptance/view-poll-test.js
+++ b/tests/acceptance/view-poll-test.js
@@ -6,6 +6,7 @@ import switchTab from 'croodle/tests/helpers/switch-tab';
 import pageParticipation from 'croodle/tests/pages/poll/participation';
 import pageEvaluation from 'croodle/tests/pages/poll/evaluation';
 import moment from 'moment';
+import { triggerCopySuccess } from 'ember-cli-clipboard/test-support';
 
 module('Acceptance | view poll', function(hooks) {
   hooks.beforeEach(function() {
@@ -27,7 +28,7 @@ module('Acceptance | view poll', function(hooks) {
       'share link is shown'
     );
 
-    pageParticipation.copyUrl();
+    await triggerCopySuccess();
     /*
      * Can't test if link is actually copied to clipboard due to api
      * restrictions. Due to security it's not allowed to read from clipboard.

--- a/tests/pages/poll.js
+++ b/tests/pages/poll.js
@@ -1,5 +1,4 @@
 import {
-  clickable,
   create,
   isVisible,
   text
@@ -13,7 +12,6 @@ const urlMatches = function(regExp) {
 };
 
 export const definition = {
-  copyUrl: clickable('.poll-link .copy-btn'),
   showsExpirationWarning: isVisible('.expiration-warning'),
   url: text('.poll-link .link a'),
   urlIsValid: urlMatches(/^\/poll\/[a-zA-Z0-9]{10}\/participation\?encryptionKey=[a-zA-Z0-9]{40}$/)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,6 +1372,13 @@ babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-p
   dependencies:
     ember-rfc176-data "^0.3.7"
 
+babel-plugin-ember-modules-api-polyfill@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.8.0.tgz#70244800f750bf1c9f380910c1b2eed1db80ab4a"
+  integrity sha512-3dlBH92qx8so2pRoks73+gwnuX97d0ajirOr96GwTZMnZxFzVR02c/PQbKWBcxpPqoL8CJSE2onuWM8PWezhOQ==
+  dependencies:
+    ember-rfc176-data "^0.3.8"
+
 babel-plugin-feature-flags@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-feature-flags/-/babel-plugin-feature-flags-0.3.1.tgz#9c827cf9a4eb9a19f725ccb239e85cab02036fc1"
@@ -2875,10 +2882,10 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
   integrity sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=
 
-clipboard@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
-  integrity sha1-Ng1taUbpmnof7zleQrqStem1oWs=
+clipboard@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.4.tgz#836dafd66cf0fea5d71ce5d5b0bf6e958009112d"
+  integrity sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==
   dependencies:
     good-listener "^1.2.2"
     select "^1.1.2"
@@ -3576,6 +3583,30 @@ ember-cli-babel@^7.0.0:
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
+ember-cli-babel@^7.1.2:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.6.0.tgz#2e7f1df888fb62eb54d170defce4b6c536e8dfd3"
+  integrity sha512-2m400ZW9c4EE343g/j1U7beJgjJezTdDCgXM2koHdhpLlZB1Kz7iQw8S+t8gzXGwSGXlf7C7v0RHxP1/bo8frA==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-modules-api-polyfill "^2.8.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
 ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.2, ember-cli-babel@^7.4.3:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.5.0.tgz#af654dcef23630391d2efe85aaa3bdf8b6ca17b7"
@@ -3646,14 +3677,14 @@ ember-cli-chart@^3.3.1:
     ember-cli-node-assets "^0.2.2"
     fastboot-transform "^0.1.2"
 
-ember-cli-clipboard@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-clipboard/-/ember-cli-clipboard-0.8.1.tgz#59f8eb6ba471a7668dff592fcebb7b06014240dd"
-  integrity sha1-Wfjra6Rxp2aN/1kvzrt7BgFCQN0=
+ember-cli-clipboard@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-clipboard/-/ember-cli-clipboard-0.11.1.tgz#caa6aaae498f12922102555d6825ad81ad843d2a"
+  integrity sha512-LAsrFpaOV8mgyI4MLR6R2BJFbzW8ac3GZkTKmAH+V5LeyidK/Inr4yZpY5nff/jKlQFT6E4991Z9mzldfKJZcg==
   dependencies:
     broccoli-funnel "^1.1.0"
-    clipboard "^1.7.1"
-    ember-cli-babel "^6.8.0"
+    clipboard "^2.0.0"
+    ember-cli-babel "^7.1.2"
     ember-cli-htmlbars "^2.0.2"
     fastboot-transform "0.1.1"
 
@@ -4446,6 +4477,11 @@ ember-rfc176-data@^0.3.6, ember-rfc176-data@^0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.7.tgz#ecff7d74987d09296d3703343fed934515a4be33"
   integrity sha512-AbTlD+q7sfyrD4diZqE7r9Y9/Je+HntVn7TlpHAe+nP5BNXxUXJIfDs5w5e3MxPcMs6Dz/yY90YfW8h1oKEvGg==
+
+ember-rfc176-data@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.8.tgz#d46bbef9a0d57c803217b258cfd2e90d8e191848"
+  integrity sha512-SQup3iG7SDLZNuf7nMMx5BC5truO8AYKRi80gApeQ07NsbuXV4LH75i5eOaxF0i8l9+H1tzv34kGe6rEh0C1NQ==
 
 ember-router-generator@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Use test helpers provided by ember-cli-clipboard as they do not trigger
confirmation in IE 11. Upgrades ember-cli-clipboard to latest version as
the outdated version used before does not include these test helpers yet.