### PR TITLE
refactor setupMirage import after upgrade of ember-cli-mirage

### DIFF
--- a/tests/acceptance/create-a-poll-test.js
+++ b/tests/acceptance/create-a-poll-test.js
@@ -1,7 +1,7 @@
 import { currentURL, currentRouteName, findAll } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-i18n/test-support';
 import { setupBrowserNavigationButtons, backButton } from 'ember-cli-browser-navigation-button-test-helper/test-support';
 import moment from 'moment';

--- a/tests/acceptance/legacy-support-test.js
+++ b/tests/acceptance/legacy-support-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-i18n/test-support';
 import switchTab from 'croodle/tests/helpers/switch-tab';
 import pollParticipate from 'croodle/tests/helpers/poll-participate';

--- a/tests/acceptance/participate-in-a-poll-test.js
+++ b/tests/acceptance/participate-in-a-poll-test.js
@@ -9,7 +9,7 @@ import {
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { t } from 'ember-i18n/test-support';
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import PollEvaluationPage from 'croodle/tests/pages/poll/evaluation';
 import pollParticipate from 'croodle/tests/helpers/poll-participate';
 

--- a/tests/acceptance/view-evaluation-test.js
+++ b/tests/acceptance/view-evaluation-test.js
@@ -1,7 +1,7 @@
 import { findAll, currentRouteName, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-i18n/test-support';
 import switchTab from 'croodle/tests/helpers/switch-tab';
 import moment from 'moment';

--- a/tests/acceptance/view-poll-test.js
+++ b/tests/acceptance/view-poll-test.js
@@ -1,7 +1,7 @@
 import { click, currentURL, currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import switchTab from 'croodle/tests/helpers/switch-tab';
 import pageParticipation from 'croodle/tests/pages/poll/participation';
 import pageEvaluation from 'croodle/tests/pages/poll/evaluation';


### PR DESCRIPTION
Recommended import path was changed in v1.0.0-beta.2: https://github.com/samselikoff/ember-cli-mirage/releases/tag/v1.0.0-beta.2