### PR TITLE
use relative URLs for assets to support serving from subdirectory

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   let ENV = {
     modulePrefix: 'croodle',
     environment,
-    rootURL: '/',
+    rootURL: '',
     locationType: 'hash',
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
Assets must be referenced using relative URLs cause otherwise croodle can't be served from subdirectories.

Can't add tests for this one cause ember requires absolute assets URLs for testing.