### PR TITLE
fix outdated CSP headers in .htaccess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
   # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
-  - if [ $TEST = "EMBER" ]; then ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'
+  - if [ $TEST = "EMBER" ]; then ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'; fi
   - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || (echo "CSP headers in public/.htaccess does not match configuration" && exit 1); fi
   # test against different browsers using sauce lab
   - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
   # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
-  - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1`" public/.htaccess || echo "CSP headers in public/.htaccess does not match configuration" && exit 1; fi
+  - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || echo "CSP headers in public/.htaccess does not match configuration" && exit 1; fi
   # test against different browsers using sauce lab
   - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi
   # test bundle size

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
   # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
-  - if [ $TEST = "EMBER" ]; then node_modules/ember-cli/bin/ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'; fi
   - if [ $TEST = "EMBER" ]; then grep "`node_modules/ember-cli/bin/ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || (echo "CSP headers in public/.htaccess does not match configuration" && exit 1); fi
   # test against different browsers using sauce lab
   - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
   # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
+  - if [ $TEST = "EMBER" ]; then ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'
   - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || (echo "CSP headers in public/.htaccess does not match configuration" && exit 1); fi
   # test against different browsers using sauce lab
   - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
   # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
-  - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || echo "CSP headers in public/.htaccess does not match configuration" && exit 1; fi
+  - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || (echo "CSP headers in public/.htaccess does not match configuration" && exit 1); fi
   # test against different browsers using sauce lab
   - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi
   # test bundle size

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:hbs; fi
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
+  # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
+  - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1`" public/.htaccess || echo "CSP headers in public/.htaccess does not match configuration" && exit 1; fi
   # test against different browsers using sauce lab
   - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi
   # test bundle size

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ script:
   - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
   - if [ $TEST = "EMBER" ]; then yarn test; fi
   # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
-  - if [ $TEST = "EMBER" ]; then ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'; fi
-  - if [ $TEST = "EMBER" ]; then grep "`ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || (echo "CSP headers in public/.htaccess does not match configuration" && exit 1); fi
+  - if [ $TEST = "EMBER" ]; then node_modules/ember-cli/bin/ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'; fi
+  - if [ $TEST = "EMBER" ]; then grep "`node_modules/ember-cli/bin/ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || (echo "CSP headers in public/.htaccess does not match configuration" && exit 1); fi
   # test against different browsers using sauce lab
   - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi
   # test bundle size

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,4 @@
 # Content Security Policy-Headers
 # you have to enable apache module headers to get them working
-#Header set Content-Security-Policy "default-src 'none'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'none';"
+#Header set Content-Security-Policy "default-src 'self'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'none';"
 #Header set Referrer-Policy "no-referrer"

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,4 @@
 # Content Security Policy-Headers
 # you have to enable apache module headers to get them working
-#Header set Content-Security-Policy "default-src 'none'; script-src 'self'; font-src 'self'; connect-src 'self'; style-src 'self';"
+#Header set Content-Security-Policy "default-src 'none'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'none';"
 #Header set Referrer-Policy "no-referrer"

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,4 @@
 # Content Security Policy-Headers
 # you have to enable apache module headers to get them working
-#Header set Content-Security-Policy "default-src 'self'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'none';"
+#Header set Content-Security-Policy "default-src 'none'; script-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'none';"
 #Header set Referrer-Policy "no-referrer"


### PR DESCRIPTION
The CSP headers in `public/.htaccess` must match the one configured in `config/environment.js`. Outdated since #205. Also adds test coverage.