### PR TITLE
remove partially filled validation error on clear

### DIFF
--- a/app/components/create-options-datetime.js
+++ b/app/components/create-options-datetime.js
@@ -159,9 +159,11 @@ export default Component.extend(modelValidations, {
   validateInput: action(function(date, event) {
     let element = event.target;
 
+    // update partially filled time validation error
     if (!element.checkValidity()) {
-      // partially filled time input
       date.set('isPartiallyFilled', true);
+    } else {
+      date.set('isPartiallyFilled', false);
     }
   }),
 });

--- a/app/components/create-options-datetime.js
+++ b/app/components/create-options-datetime.js
@@ -150,12 +150,14 @@ export default Component.extend(modelValidations, {
   store: service(),
 
   inputChanged: action(function(date, value) {
+    // update property, which is normally done by default
+    date.set('time', value);
+
     // reset partially filled state
     date.set('isPartiallyFilled', false);
-
-    date.set('time', value);
   }),
 
+  // validate input field for being partially filled
   validateInput: action(function(date, event) {
     let element = event.target;
 
@@ -163,6 +165,15 @@ export default Component.extend(modelValidations, {
     if (!element.checkValidity()) {
       date.set('isPartiallyFilled', true);
     } else {
+      date.set('isPartiallyFilled', false);
+    }
+  }),
+
+  // remove partially filled validation error if user fixed it
+  updateInputValidation: action(function(date, event) {
+    let element = event.target;
+
+    if (element.checkValidity() && date.isPartiallyFilled) {
       date.set('isPartiallyFilled', false);
     }
   }),

--- a/app/templates/components/create-options-datetime.hbs
+++ b/app/templates/components/create-options-datetime.hbs
@@ -44,12 +44,30 @@
             <div class="input-group">
               <el.control
                 @autofocus={{unless index true false}}
-                @onChange={{action this.inputChanged date}}
+                @onChange={{fn this.inputChanged date}}
                 @placeholder="00:00"
                 @type="time"
                 @value={{el.value}}
 
-                {{on "focusout" (action this.validateInput date)}}
+                {{! run validation for partially filled input on focusout event }}
+                {{on "focusout" (fn this.validateInput date)}}
+
+                {{!--
+                  Validation for partially input field must be reset if input is cleared.
+                  But `@onChange` is not called and `focusout` event not triggered in that
+                  scenario. Need to listen to additional events to ensure that partially
+                  input validation is updated as soon as user fixed a partially input.
+                  The `keyup` events captures all scenarios in which the input is cleared
+                  using keyboard. `focusin` event is triggered if user clicks the clears
+                  button provided by native input. As a fallback validation is rerun on
+                  `focusout`.
+                  As the time of implementation this was only affecting Chrome cause
+                  Firefox does not consider partially time input as invalid, Edge prevents
+                  partially filling in first place and Desktop Safari as well as IE 11
+                  do not support `<input type="time">`.
+                --}}
+                {{on "focusin" (fn this.updateInputValidation date)}}
+                {{on "keyup" (fn this.updateInputValidation date)}}
 
                 id={{el.id}}
               />


### PR DESCRIPTION
Change event is not triggered on clear if field was only partially filled. Therefor validation error may not be cleared if only relying on change event. It should at least also be removed if element loose focus.

It would be even better if validation error is updated directly after user clears the input. But that's not an easy one as neither change nor input element are triggered reliable. But as far as I've tested it should work by listening to this events:

- `keyup` evnet is fired if input is cleared with keyboard (e.g. backspace).
- `focusin` event is fired if input is cleared using button provided by native UI. (`input` event is only fired if element does not have focus before.)

Please note that only Chrome is affected as that's the only browser showing that validation error.

Closes #281 