### PR TITLE
Add colors indicating selections to participants table again

### DIFF
--- a/app/styles/_participants-table.scss
+++ b/app/styles/_participants-table.scss
@@ -42,6 +42,18 @@
           }
         }
       }
+
+      tbody {
+        td {
+          &.yes {
+            background-color: #c6ffbf;
+          }
+
+          &.no {
+            background-color: #ffbabc;
+          }
+        }
+      }
     }
   }
 }

--- a/app/templates/components/poll-evaluation-participants-table.hbs
+++ b/app/templates/components/poll-evaluation-participants-table.hbs
@@ -46,23 +46,19 @@
             {{user.name}}
           </td>
           {{#each this.options as |option index|}}
-            <td
-              data-test-is-selection-cell
-              data-test-value-for={{option.value}}
-            >
-              {{#let (object-at index user.selections) as |selection|}}
-                {{#if this.isFreeText}}
-                  {{selection.label}}
+            {{#let (object-at index user.selections) as |selection|}}
+              <td
+                class={{selection.type}}
+                data-test-is-selection-cell
+                data-test-value-for={{option.value}}
+              >
+                {{#if selection.labelTranslation}}
+                  {{t selection.labelTranslation}}
                 {{else}}
-                  {{#if selection.type}}
-                    <span class={{selection.type}}>
-                      <span class={{selection.icon}}></span>
-                      {{t selection.labelTranslation}}
-                    </span>
-                  {{/if}}
+                  {{selection.label}}
                 {{/if}}
-              {{/let}}
-            </td>
+              </td>
+            {{/let}}
           {{/each}}
         </tr>
       {{/each}}


### PR DESCRIPTION
Colors and icons indicating the selections where dropped in #205. This adds the colors to visual highlight *yes* and *no* selections as they help a lot to visually detect patterns in the result table.

![simple](https://user-images.githubusercontent.com/4965703/68528761-508fcb00-02f7-11ea-9848-1befb5785fa7.png)

*Maybe* selection and empty selection don't have a background color:

![maybe](https://user-images.githubusercontent.com/4965703/68528768-7026f380-02f7-11ea-9eb9-c6228facb6d6.png)
![not-everything-answered](https://user-images.githubusercontent.com/4965703/68528769-7321e400-02f7-11ea-83d6-1f8348881ccd.png)

Design implemented was proposed by @sappor0 in https://github.com/jelhan/croodle/issues/274#issuecomment-548795535.

Closes #274 