### PR TITLE
add abort button to retry save modal and several other fixes for it

### DIFF
--- a/app/locales/ca/translations.js
+++ b/app/locales/ca/translations.js
@@ -1,4 +1,5 @@
 export default {
+  'action.abort': 'Abort',
   'action.back': 'Enrere',
   'action.next': 'Següent',
   'action.save': 'Desa',

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -1,4 +1,5 @@
 export default {
+  'action.abort': 'Abbrechen',
   'action.back': 'Zurück',
   'action.next': 'Weiter',
   'action.save': 'Speichern',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -1,4 +1,5 @@
 export default {
+  'action.abort': 'Abort',
   'action.back': 'Back',
   'action.next': 'Next',
   'action.save': 'Save',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -1,4 +1,5 @@
 export default {
+  'action.abort': 'Abort',
   'action.back': 'Atras',
   'action.next': 'Siguiente',
   'action.save': 'Guardar',

--- a/app/locales/it/translations.js
+++ b/app/locales/it/translations.js
@@ -1,4 +1,5 @@
 export default {
+  'action.abort': 'Abort',
   'action.back': 'Indietro',
   'action.next': 'Avanti',
   'action.save': 'Salvare',

--- a/app/templates/poll/participation.hbs
+++ b/app/templates/poll/participation.hbs
@@ -80,24 +80,32 @@
   {{/bs-form}}
 </div>
 
-{{#bs-modal
-  open=savingFailed
-  title=(t "modal.save-retry.title")
-  body=false
-  footer=false
-  closeButton=false
-  autoClose=false
-  id="modal-saving-failed"
-as |modal|
-}}
-  {{#modal.body}}
+<BsModal
+  @id="modal-saving-failed-modal"
+  @onHidden={{action (mut savingFailed) false}}
+  @onSubmit={{action "save"}}
+  @open={{savingFailed}}
+  as |modal|
+>
+  <modal.header
+    @closeButton={{false}}
+    @title={{t "modal.save-retry.title"}}
+  />
+  <modal.body>
     <p>{{t "modal.save-retry.text"}}</p>
-  {{/modal.body}}
-  {{#modal.footer}}
-    {{bs-button
-      defaultText=(t "modal.save-retry.button-retry")
-      type="primary"
-      onClick=(action "save")
-    }}
-  {{/modal.footer}}
-{{/bs-modal}}
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      @onClick={{action modal.close}}
+    >
+      {{t "action.abort"}}
+    </BsButton>
+    <BsButton
+      @type="primary"
+      @onClick={{action modal.submit}}
+      data-test-button="retry"
+    >
+      {{t "modal.save-retry.button-retry"}}
+    </BsButton>
+  </modal.footer>
+</BsModal>

--- a/tests/acceptance/participate-in-a-poll-test.js
+++ b/tests/acceptance/participate-in-a-poll-test.js
@@ -150,18 +150,18 @@ module('Acceptance | participate in a poll', function(hooks) {
 
     await visit(`/poll/${poll.id}/participation?encryptionKey=${encryptionKey}`);
     assert.equal(currentRouteName(), 'poll.participation');
-    assert.dom('modal-saving-failed-modal')
-      .doesNotExist('failed saving notification is not shown before attempt to save');
+    assert.dom('#modal-saving-failed-modal .modal-content')
+      .isNotVisible('failed saving notification is not shown before attempt to save');
 
     await pollParticipate('John Doe', ['yes', 'no']);
-    assert.dom('#modal-saving-failed-modal')
-      .exists('user gets notified that saving failed');
+    assert.dom('#modal-saving-failed-modal .modal-content')
+      .isVisible('user gets notified that saving failed');
 
     this.server.post('/users');
 
-    await click('#modal-saving-failed-modal button');
-    assert.dom('#modal-saving-failed-modal')
-      .doesNotExist('Notification is hidden after another save attempt was successful');
+    await click('#modal-saving-failed-modal [data-test-button="retry"]');
+    assert.dom('#modal-saving-failed-modal .modal-content')
+      .isNotVisible('Notification is hidden after another save attempt was successful');
     assert.equal(currentRouteName(), 'poll.evaluation');
     assert.equal(PollEvaluationPage.participants.length, 1, 'user is added to participants table');
 


### PR DESCRIPTION
Croodle shows a modal if saving a participation fails. The modal allows a user to retry the save attempt. While it was always possible to close the button by clicking on backdrop or using escape key, a button to do so was missing. A user may not know about the user ways and may see reloading
the page as only possibilty to close the modal if he doesn't want to retry again.

This adds the missing abort button and fixes some smaller bugs including:

- The modal was missing a title.
- If the modal was closed once it wasn't reopened on another failed saving attempt unless the user has visit another page in between.
- Several arguments were passed to `<BsModal>` that weren't existing at all.