### PR TITLE
validation become visible should not alter position of calendar

### DIFF
--- a/app/styles/_generic-croodle-styles.scss
+++ b/app/styles/_generic-croodle-styles.scss
@@ -28,3 +28,9 @@
 .cr-h-auto {
   height: auto !important;
 }
+
+// adds the same padding-right as .is-valid / .is-invalid validation feedback
+// classes provided by Bootstrap do
+.cr-pr-validation {
+  padding-right: calc(1.5em + .74rem);
+}

--- a/app/templates/components/create-options-dates.hbs
+++ b/app/templates/components/create-options-dates.hbs
@@ -9,6 +9,7 @@
       class="
         form-control
         cr-h-auto
+        cr-pr-validation
         {{if (eq el.validation "error") "is-invalid"}}
         {{if (eq el.validation "success") "is-valid"}}
       "


### PR DESCRIPTION
Validation status becoming visible has caused the calendars to move left by a few pixels.

### Before

![before](https://user-images.githubusercontent.com/4965703/68575507-830f0480-046c-11ea-87cf-488f2e606a45.gif)

### After

![after](https://user-images.githubusercontent.com/4965703/68575528-8a361280-046c-11ea-95c2-b94e0d767a66.gif)
