### PR TITLE
Document build without requiring Ember CLI to be installed globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone git@github.com:jelhan/croodle.git
 cd croodle
 yarn install
 cd api/ && composer install --no-dev && cd ..
-ember build --prod
+yarn build -- --prod
 ```
 
 Afterwards copy all files in `/dist` folder to your werbserver.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone git@github.com:jelhan/croodle.git
 cd croodle
 yarn install
 cd api/ && composer install --no-dev && cd ..
-yarn build -- --prod
+yarn build --prod
 ```
 
 Afterwards copy all files in `/dist` folder to your werbserver.


### PR DESCRIPTION
Fix build ember production command. With this change you make sure that the ember version of the project is used and not the global installed from the developer