### PR TITLE
Add and delete buttons should indicate focus

### DIFF
--- a/app/styles/_open-iconic.scss
+++ b/app/styles/_open-iconic.scss
@@ -1,0 +1,12 @@
+@import "open-iconic/font/css/open-iconic-bootstrap.scss";
+
+.oi {
+  // open-iconic uses `display: inline-block` by default which prevents text
+  // decorations to be applied. Text decorations like underscore are used to
+  // indicate that an element is focusable. Not showing them by default is
+  // easily causing accessibility issue. We change the default to
+  // `display: inline` to have a safe default behavior. It could be easily
+  // overruled per element by applying Bootstrap's utility class
+  // `.d-inline-block`.
+  display: inline;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -12,7 +12,7 @@
 @import "ember-bootstrap/reboot";
 
 // Open Iconic icon font
-@import "open-iconic/font/css/open-iconic-bootstrap.scss";
+@import "./open-iconic";
 
 // Optional - Everything else
 @import "ember-bootstrap/utilities/display";


### PR DESCRIPTION
Add and delete buttons used for option creation don't have any text (except for screenreader) but only an icon. Open Iconic uses a display: inline-block for icons as default. But that one prevents text decoration from being applied. Since text decoration is used to visually indicate focus, that's a serious
accessibility issue.

Closes #293