### PR TITLE
improve spanish translation

### DIFF
--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -150,7 +150,7 @@ export default {
     url: '{{description}} debe de ser una URL valida',
     time: '{{description}} debe de ser un horario valido (p.ej. 10:45)',
     'time.notPartially': 'Partially times are not supported',
-    unique: '{{description}} debe de ser único',
+    unique: '{{description}} deben ser explícitas',
     'unique.name': 'Este nombre ya está usado'
   }
 };


### PR DESCRIPTION
Accordingly to a spanish user the translation for validation error "Times must be explicit" should be "Horas deben ser explícitas". Changed the template accordingly. Hopefully that also makes sense for other unique validations.

Closes #311