### PR TITLE
add separate section for i18n to changelog

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,7 @@ When reviewing merged PR's the labels to be used are:
 * enhancement - Used when the PR adds a new feature or enhancement.
 * bug - Used when the PR fixes a bug included in a previous release.
 * documentation - Used when the PR adds or updates documentation.
+* i18n - Used when the PR adds new locales or improves existing translations.
 * internal - Used for internal changes that still require a mention in the
   changelog/release notes.
 

--- a/package.json
+++ b/package.json
@@ -94,5 +94,15 @@
   },
   "resolutions": {
     "chart.js": "~2.6.0"
+  },
+  "changelog": {
+    "labels": {
+      "breaking": ":boom: Breaking Change",
+      "enhancement": ":rocket: Enhancement",
+      "bug": ":bug: Bug Fix",
+      "documentation": ":memo: Documentation",
+      "i18n": ":abc: Internalization",
+      "internal": ":house: Internal"
+    }
   }
 }


### PR DESCRIPTION
Adds a separate section for internationalization to the changelog. Will include all PRs that are labeled with `i18n`.