### PR TITLE
do not include self-reference . folder in release archive

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -10,7 +10,7 @@
   },
   "hooks": {
     "before:git:bump": "yarn install && ember build --prod",
-    "before:github:release": "cd dist && tar -czf ../croodle.tar.gz --exclude .. * .* && mv ../croodle.tar.gz croodle-v${version}.tar.gz"
+    "before:github:release": "cd dist && tar -czf ../croodle.tar.gz --exclude . --exclude .. * .* && mv ../croodle.tar.gz croodle-v${version}.tar.gz"
   },
   "npm": {
     "publish": false


### PR DESCRIPTION
The archive created on release was including `.` folder, which is a self-reference in unix file system. This results in a very strange archive and issues with extracting it in some situations.