### PR TITLE
convert component invocation to angle brackets

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,12 +1,16 @@
-{{head-layout}}
+<HeadLayout />
 
 {{title "Croodle"}}
 
 <nav class="cr-navbar navbar navbar-dark">
-  <h1 class="cr-logo">{{#link-to "index" class="navbar-brand"}}Croodle{{/link-to}}</h1>
+  <h1 class="cr-logo">
+    <LinkTo @route="index" class="navbar-brand">
+      Croodle
+    </LinkTo>
+  </h1>
   <div class="collapse" id="headerNavbar">
     <form class="form-inline my-2 my-lg-0">
-      {{language-select class="custom-select custom-select-sm"}}
+      <LanguageSelect class="custom-select custom-select-sm" />
     </form>
   </div>
 </nav>
@@ -14,9 +18,9 @@
 <main role="main" class="container cr-main">
   <div id="messages">
     {{#each flashMessages.queue as |flash|}}
-      {{#flash-message flash=flash}}
+      <FlashMessage @flash={{flash}}>
         {{t flash.message}}
-      {{/flash-message}}
+      </FlashMessage>
     {{/each}}
   </div>
 

--- a/app/templates/components/create-options.hbs
+++ b/app/templates/components/create-options.hbs
@@ -1,25 +1,16 @@
 <div class="cr-form-wrapper box">
-  {{#bs-form
-    action="submit"
-    formLayout="horizontal"
-    model=this
-    novalidate=true
-    onInvalid=(scroll-first-invalid-element-into-view-port)
-    onSubmit=(action "submit")
-  as |form|
-  }}
+  <BsForm
+    @formLayout="horizontal"
+    @model={{this}}
+    @onInvalid={{scroll-first-invalid-element-into-view-port}}
+    @onSubmit={{action "submit"}}
+    novalidate
+    as |form|
+  >
     {{#if isMakeAPoll}}
-      {{create-options-text
-        options=options
-        addOption="addOption"
-        deleteOption="deleteOption"
-        form=form
-      }}
+      <CreateOptionsText @options={{options}} @addOption="addOption" @deleteOption="deleteOption" @form={{form}} />
     {{else}}
-      {{create-options-dates
-        options=options
-        form=form
-      }}
+      <CreateOptionsDates @options={{options}} @form={{form}} />
     {{/if}}
 
     <div class="row cr-steps-bottom-nav">
@@ -30,5 +21,5 @@
         <BackButton @onClick={{action "previousPage"}} />
       </div>
     </div>
-  {{/bs-form}}
+  </BsForm>
 </div>

--- a/app/templates/components/poll-evaluation-chart.hbs
+++ b/app/templates/components/poll-evaluation-chart.hbs
@@ -1,5 +1,1 @@
-{{ember-chart
-  type="bar"
-  data=data
-  options=chartOptions
-}}
+<EmberChart @type="bar" @data={{data}} @options={{chartOptions}} />

--- a/app/templates/components/poll-evaluation-summary.hbs
+++ b/app/templates/components/poll-evaluation-summary.hbs
@@ -22,25 +22,25 @@
   {{#if multipleBestOptions}}
     <ul>
       {{#each bestOptions as |evaluationBestOption|}}
-        {{poll-evaluation-summary-option
-          currentLocale=currentLocale
-          evaluationBestOption=evaluationBestOption
-          isFindADate=poll.isFindADate
-          momentLongDayFormat=momentLongDayFormat
-          tagName="li"
-          timezone=timezone
-        }}
+        <PollEvaluationSummaryOption
+          @currentLocale={{currentLocale}}
+          @evaluationBestOption={{evaluationBestOption}}
+          @isFindADate={{poll.isFindADate}}
+          @momentLongDayFormat={{momentLongDayFormat}}
+          @tagName="li"
+          @timezone={{timezone}}
+        />
       {{/each}}
     </ul>
   {{else}}
-    {{poll-evaluation-summary-option
-      currentLocale=currentLocale
-      evaluationBestOption=bestOptions.firstObject
-      isFindADate=poll.isFindADate
-      momentLongDayFormat=momentLongDayFormat
-      tagName="span"
-      timezone=timezone
-    }}
+    <PollEvaluationSummaryOption
+      @currentLocale={{currentLocale}}
+      @evaluationBestOption={{bestOptions.firstObject}}
+      @isFindADate={{poll.isFindADate}}
+      @momentLongDayFormat={{momentLongDayFormat}}
+      @tagName="span"
+      @timezone={{timezone}}
+    />
   {{/if}}
 </p>
 

--- a/app/templates/create/index.hbs
+++ b/app/templates/create/index.hbs
@@ -1,34 +1,34 @@
 <div class="cr-form-wrapper box">
-  {{#bs-form
-    formLayout="horizontal"
-    model=this
-    novalidate=true
-    onInvalid=(scroll-first-invalid-element-into-view-port)
-    onSubmit=(action "submit")
-  as |form|
-  }}
-    {{#form.element
-      classNames="poll-type"
-      label=(t "create.index.input.pollType.label")
-      property="pollType"
-      showValidationOn=(array "change" "focusOut")
-      useIcons=false
-    as |el|
-    }}
-      {{#autofocusable-element
-        tagName="select"
-        change=(action (mut el.value) value="target.value")
-        id=el.id
+  <BsForm
+    @formLayout="horizontal"
+    @model={{this}}
+    @onInvalid={{scroll-first-invalid-element-into-view-port }}
+    @onSubmit={{action "submit"}}
+    novalidate
+    as |form|
+  >
+    <form.element
+      @label={{t "create.index.input.pollType.label"}}
+      @property="pollType"
+      @showValidationOn={{array "change" "focusOut"}}
+      @useIcons={{false}}
+      class="poll-type"
+      as |el|
+    >
+      <AutofocusableElement
+        @tagName="select"
+        @change={{action (mut el.value) value="target.value"}}
+        id={{el.id}}
         class="form-control"
-      }}
+      >
         <option value="FindADate" selected={{eq el.value "FindADate"}}>
           {{t "pollTypes.findADate.label"}}
         </option>
         <option value="MakeAPoll" selected={{eq el.value "MakeAPoll"}}>
           {{t "pollTypes.makeAPoll.label"}}
         </option>
-      {{/autofocusable-element}}
-    {{/form.element}}
+      </AutofocusableElement>
+    </form.element>
 
     <div class="row cr-steps-bottom-nav">
       <div class="col-6 col-md-8 order-12">
@@ -38,5 +38,5 @@
         <BackButton @disabled={{true}} />
       </div>
     </div>
-  {{/bs-form}}
+  </BsForm>
 </div>

--- a/app/templates/create/meta.hbs
+++ b/app/templates/create/meta.hbs
@@ -1,27 +1,27 @@
 <div class="cr-form-wrapper box">
-  {{#bs-form
-    formLayout="horizontal"
-    model=this
-    novalidate=true
-    onInvalid=(scroll-first-invalid-element-into-view-port)
-    onSubmit=(action "submit")
-  as |form|
-  }}
-    {{form.element
-      autofocus=true
-      classNames="title"
-      controlType="text"
-      label=(t "create.meta.input.title.label")
-      placeholder=(t "create.meta.input.title.placeholder")
-      property="title"
-    }}
-    {{form.element
-      classNames="description"
-      controlType="textarea"
-      label=(t "create.meta.input.description.label")
-      placeholder=(t "create.meta.input.description.placeholder")
-      property="description"
-    }}
+  <BsForm
+    @formLayout="horizontal"
+    @model={{this}}
+    @onInvalid={{scroll-first-invalid-element-into-view-port}}
+    @onSubmit={{action "submit"}}
+    novalidate
+    as |form|
+  >
+    <form.element
+      @autofocus={{true}}
+      @controlType="text"
+      @label={{t "create.meta.input.title.label"}}
+      @placeholder={{t "create.meta.input.title.placeholder"}}
+      @property="title"
+      class="title"
+    />
+    <form.element
+      @controlType="textarea"
+      @label={{t "create.meta.input.description.label"}}
+      @placeholder={{t "create.meta.input.description.placeholder"}}
+      @property="description"
+      class="description"
+    />
 
     <div class="row cr-steps-bottom-nav">
       <div class="col-6 col-md-8 order-12">
@@ -31,5 +31,5 @@
         <BackButton @onClick={{action "previousPage"}} />
       </div>
     </div>
-  {{/bs-form}}
+  </BsForm>
 </div>

--- a/app/templates/create/options-datetime.hbs
+++ b/app/templates/create/options-datetime.hbs
@@ -1,5 +1,5 @@
-{{create-options-datetime
-  dates=options
-  onNextPage=(action "nextPage")
-  onPrevPage=(action "previousPage")
-}}
+<CreateOptionsDatetime
+  @dates={{options}}
+  @onNextPage={{action "nextPage"}}
+  @onPrevPage={{action "previousPage"}}
+/>

--- a/app/templates/create/options.hbs
+++ b/app/templates/create/options.hbs
@@ -1,7 +1,7 @@
-{{create-options
-  isFindADate=model.isFindADate
-  isMakeAPoll=model.isMakeAPoll
-  options=model.options
-  onPrevPage=(action "previousPage")
-  onNextPage=(action "nextPage")
-}}
+<CreateOptions
+  @isFindADate={{model.isFindADate}}
+  @isMakeAPoll={{model.isMakeAPoll}}
+  @options={{model.options}}
+  @onPrevPage={{action "previousPage"}}
+  @onNextPage={{action "nextPage"}}
+/>

--- a/app/templates/create/settings.hbs
+++ b/app/templates/create/settings.hbs
@@ -1,42 +1,42 @@
 <div class="cr-form-wrapper box">
-  {{#bs-form
-    formLayout="horizontal"
-    model=this
-    novalidate=true
-    onInvalid=(scroll-first-invalid-element-into-view-port)
-    onSubmit=(action "submit")
-  as |form|
-  }}
-    {{#form.element
-      classNames="answer-type"
-      label=(t "create.settings.answerType.label")
-      property="answerType"
-      showValidationOn=(array "change" "focusOut")
-      useIcons=false
-    as |el|
-    }}
-      {{#autofocusable-element
-        tagName="select"
-        change=(action "updateAnswerType" value="target.value")
-        id=el.id
+  <BsForm
+    @formLayout="horizontal"
+    @model={{this}}
+    @novalidate={{true}}
+    @onInvalid={{scroll-first-invalid-element-into-view-port }}
+    @onSubmit={{action "submit"}}
+    as |form|
+  >
+    <form.element
+      @label={{t "create.settings.answerType.label"}}
+      @property="answerType"
+      @showValidationOn={{array "change" "focusOut"}}
+      @useIcons={{false}}
+      class="answer-type"
+      as |el|
+    >
+      <AutofocusableElement
+        @tagName="select"
+        @change={{action "updateAnswerType" value="target.value"}}
+        id={{el.id}}
         class="custom-select"
-      }}
+      >
         {{#each answerTypes as |answerType|}}
           <option value={{answerType.id}} selected={{eq el.value answerType.id}}>
             {{t answerType.labelTranslation}}
           </option>
         {{/each}}
-      {{/autofocusable-element}}
-    {{/form.element}}
-    {{#form.element
-      classNames="expiration-duration"
-      label=(t "create.settings.expirationDate.label")
-      property="expirationDuration"
-      showValidationOn=(array "change" "focusOut")
-      useIcons=false
-      controlType="select"
-    as |el|
-    }}
+      </AutofocusableElement>
+    </form.element>
+    <form.element
+      @controlType="select"
+      @label={{t "create.settings.expirationDate.label"}}
+      @property="expirationDuration"
+      @showValidationOn={{array "change" "focusOut"}}
+      @useIcons={{false}}
+      class="expiration-duration"
+      as |el|
+    >
       <select
         id={{el.id}}
         onchange={{action (mut el.value) value="target.value"}}
@@ -48,21 +48,21 @@
           </option>
         {{/each}}
       </select>
-    {{/form.element}}
-    {{form.element
-      classNames="anonymous-user"
-      controlType="checkbox"
-      label=(t "create.settings.anonymousUser.label")
-      showValidationOn="change"
-      property="anonymousUser"
-    }}
-    {{form.element
-      classNames="force-answer"
-      controlType="checkbox"
-      label=(t "create.settings.forceAnswer.label")
-      showValidationOn="change"
-      property="forceAnswer"
-    }}
+    </form.element>
+    <form.element
+      @controlType="checkbox"
+      @label={{t "create.settings.anonymousUser.label"}}
+      @showValidationOn="change"
+      @property="anonymousUser"
+      class="anonymous-user"
+    />
+    <form.element
+      @controlType="checkbox"
+      @label={{t "create.settings.forceAnswer.label"}}
+      @showValidationOn="change"
+      @property="forceAnswer"
+      class="force-answer"
+    />
 
     <div class="row cr-steps-bottom-nav">
       <div class="col-6 col-md-8 order-12">
@@ -72,5 +72,5 @@
         <BackButton @onClick={{action "previousPage"}} />
       </div>
     </div>
-  {{/bs-form}}
+  </BsForm>
 </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -4,7 +4,9 @@
     <h2 class="cr-claim">
       {{t "index.title"}}
     </h2>
-    {{#link-to "create" class="btn btn-primary btn-lg"}}{{t "index.link.have-a-try"}}{{/link-to}}
+    <LinkTo @route="create" class="btn btn-primary btn-lg">
+      {{t "index.link.have-a-try"}}
+    </LinkTo>
   </div>
 
   <div class="row">

--- a/app/templates/poll.hbs
+++ b/app/templates/poll.hbs
@@ -32,15 +32,15 @@
           <small>
             <code class="cr-poll-link__url">{{pollUrl}}</code>
           </small>
-          {{#copy-button
-            clipboardText=pollUrl
-            classNames="btn btn-secondary cr-poll-link__copy-btn btn-sm"
-            success=(action "linkAction" "copied")
-            error=(action "linkAction" "selected")
-          }}
+          <CopyButton
+            @clipboardText={{pollUrl}}
+            @error={{action "linkAction" "selected"}}
+            @success={{action "linkAction" "copied"}}
+            class="btn btn-secondary cr-poll-link__copy-btn btn-sm"
+          >
             {{t "poll.link.copy-label"}}&nbsp;
             <span class="oi oi-clipboard" title={{t "poll.link.copy-label"}} aria-hidden="true"></span>
-          {{/copy-button}}
+          </CopyButton>
         </p>
         <small class="text-muted">
           {{t "poll.share.notice"}}
@@ -52,40 +52,28 @@
   {{#if showExpirationWarning}}
     <div class="row">
       <div class="col-xs-12">
-        {{#bs-alert type="warning" classNames="expiration-warning"}}
+        <BsAlert @type="warning" class="expiration-warning">
           {{t
             "poll.expiration-date-warning"
             timeToNow=(moment-from-now model.expirationDate locale=currentLocale)
           }}
-        {{/bs-alert}}
+        </BsAlert>
       </div>
     </div>
   {{/if}}
 
   <div class="box">
     <ul class="nav nav-tabs" role="tablist">
-      {{#link-to
-        "poll.participation"
-        model
-        tagName="li"
-        activeClass="active"
-        class="participation nav-item"
-      }}
-        {{#link-to "poll.participation" model class="nav-link"}}
+      <LinkTo @route="poll.participation" @model={{model}} @tagName="li" @activeClass="active" class="participation nav-item">
+        <LinkTo @route="poll.participation" @model={{model}} class="nav-link">
           {{t "poll.tab-title.participation"}}
-        {{/link-to}}
-      {{/link-to}}
-      {{#link-to
-        "poll.evaluation"
-        model
-        tagName="li"
-        activeClass="active"
-        class="evaluation nav-item"
-      }}
-        {{#link-to "poll.evaluation" model class="nav-link"}}
+        </LinkTo>
+      </LinkTo>
+      <LinkTo @route="poll.evaluation" @model={{model}} @tagName="li" @activeClass="active" class="evaluation nav-item">
+        <LinkTo @route="poll.evaluation" @model={{model}} class="nav-link">
           {{t "poll.tab-title.evaluation"}}
-        {{/link-to}}
-      {{/link-to}}
+        </LinkTo>
+      </LinkTo>
     </ul>
 
     <div class="tab-content">

--- a/app/templates/poll/evaluation.hbs
+++ b/app/templates/poll/evaluation.hbs
@@ -1,21 +1,21 @@
 {{#if isEvaluable}}
-  {{poll-evaluation-summary
-    momentLongDayFormat=momentLongDayFormat
-    poll=poll
-    timezone=timezone
-  }}
+  <PollEvaluationSummary
+    @momentLongDayFormat={{momentLongDayFormat}}
+    @poll={{poll}}
+    @timezone={{timezone}}
+  />
 
   <h3>{{t "poll.evaluation.overview"}}</h3>
-  {{poll-evaluation-chart
-    momentLongDayFormat=momentLongDayFormat
-    poll=poll
-    timezone=timezone
-  }}
+  <PollEvaluationChart
+    @momentLongDayFormat={{momentLongDayFormat}}
+    @poll={{poll}}
+    @timezone={{timezone}}
+  />
 {{/if}}
 
 <h3>{{t "poll.evaluation.participantTable"}}</h3>
-{{poll-evaluation-participants-table
-  momentLongDayFormat=momentLongDayFormat
-  poll=poll
-  timezone=timezone
-}}
+<PollEvaluationParticipantsTable
+  @momentLongDayFormat={{momentLongDayFormat}}
+  @poll={{poll}}
+  @timezone={{timezone}}
+/>

--- a/app/templates/poll/participation.hbs
+++ b/app/templates/poll/participation.hbs
@@ -1,27 +1,27 @@
 <div class="participation cr-form-wrapper">
-  {{#bs-form
-    onInvalid=(scroll-first-invalid-element-into-view-port)
-    onSubmit=(action "submit")
-    formLayout="horizontal"
-    model=this
-    novalidate=true
-  as |form|
-  }}
-    {{form.element
-      autofocus=true
-      controlType="text"
-      label=(t "poll.input.newUserName.label")
-      placeholder=(t "poll.input.newUserName.placeholder")
-      property="name"
-      classNames="name"
+  <BsForm
+    @formLayout="horizontal"
+    @model={{this}}
+    @onInvalid={{scroll-first-invalid-element-into-view-port}}
+    @onSubmit={{action "submit"}}
+    novalidate
+    as |form|
+  >
+    <form.element
+      @autofocus={{true}}
+      @controlType="text"
+      @label={{t "poll.input.newUserName.label"}}
+      @placeholder={{t "poll.input.newUserName.placeholder"}}
+      @property="name"
+      class="name"
       data-test-form-element="name"
-    }}
+    />
     <div class="selections">
       {{#each selections as |selection|}}
         {{#if isFreeText}}
-          {{form.element
-            controlType="text"
-            label=(if isFindADate
+          <form.element
+            @controlType="text"
+            @label={{if isFindADate
               (moment-format
                 selection.labelValue
                 (if (eq selection.momentFormat "day") momentLongDayFormat selection.momentFormat)
@@ -29,13 +29,13 @@
                 timeZone=timezone
               )
               selection.labelValue
-            )
-            model=selection
-            property="value"
-          }}
+            }}
+            @model={{selection}}
+            @property="value"
+          />
         {{else}}
-          {{#form.element
-            label=(if isFindADate
+          <form.element
+            @label={{if isFindADate
               (moment-format
                 selection.labelValue
                 (if (eq selection.momentFormat "day") momentLongDayFormat selection.momentFormat)
@@ -43,14 +43,14 @@
                 timeZone=timezone
               )
               selection.labelValue
-            )
-            model=selection
-            property="value"
-            showValidationOn="change"
-            useIcons=false
-            data-test-form-element=(concat "option-" selection.labelValue)
-          as |el|
-          }}
+            }}
+            @model={{selection}}
+            @property="value"
+            @showValidationOn="change"
+            @useIcons={{false}}
+            data-test-form-element={{concat "option-" selection.labelValue}}
+            as |el|
+          >
             {{#each possibleAnswers as |possibleAnswer|}}
               <div class="radio custom-control custom-radio custom-control-inline {{possibleAnswer.type}}">
                 <input
@@ -70,7 +70,7 @@
                 </label>
               </div>
             {{/each}}
-          {{/form.element}}
+          </form.element>
         {{/if}}
       {{/each}}
     </div>
@@ -80,7 +80,7 @@
         <SaveButton @isPending={{form.isSubmitting}} data-test-button="submit" />
       </div>
     </div>
-  {{/bs-form}}
+  </BsForm>
 </div>
 
 <BsModal


### PR DESCRIPTION
Angle bracket component invocation (`<MyComponent @arg="foo" class="bar" />`) is a new syntax to invoke a component in Ember. It replaces the old curly bracket invocation (`{{my-component arg="foo" class="bar"}}`) style.

The new syntax makes the templates more readable. It helps to distinguish components from helpers and values. Also it allows to pass HTML attributes to a component directly and does not require a mapping from arguments to HTML attributes anymore.

You could find more information in Ember's upgrade guides: https://guides.emberjs.com/release/upgrading/current-edition/templates/#toc_angle-bracket-syntax

Most of the conversion was done automatically by [ember-angle-bracket-codemod](https://github.com/ember-codemods/ember-angle-brackets-codemod). Only needed to fix a few lines of code after running the codemod.