### PR TITLE
fix broken link to GitHub on landing page

### DIFF
--- a/app/locales/ca/translations.js
+++ b/app/locales/ca/translations.js
@@ -63,7 +63,7 @@ export default {
   'index.features.list.evaluation': 'Podeu consultar una revisió automàtica actualitzada de les <strong>respostes preferides</strong>.',
   'index.link.have-a-try': 'Prova-ho ara',
   'index.hoster.title': 'Hoste el vostre Croodle:',
-  'index.hoster.text': 'No has de confiar en aquest Croodle. Croodle és un programari lliure i el podeu instal·lar al vostre propi servidor. Només necessiteu un servidor amb un espai de uns quans mega bytes, PHP i xifratge SSL. El programari i consells per a la instal·lació estan aquí:<a href=\'https://github.com/jelhan/croodle\'>GitHub</a>.',
+  'index.hoster.text': 'No has de confiar en aquest Croodle. Croodle és un programari lliure i el podeu instal·lar al vostre propi servidor. Només necessiteu un servidor amb un espai de uns quans mega bytes, PHP i xifratge SSL. El programari i consells per a la instal·lació estan aquí: {{{gitHubLink}}}.',
   'modal.save-retry.title': 'S\'ha produït un error en desar.',
   'modal.save-retry.text': '<p> No s\'ha pogut desar la teva assistència. Comproveu la vostra connexió a Internet i torneu-ho a provar.</p><p>Si això no funciona, és possible que es produeixi una desconexiò temporal del servidor. Espereu uns minuts abans d\'entrenar-hi. Podeu deixar la pàgina oberta.</p><p>Si els problemes continuen, poseu-vos en contacte amb l\'administrador d\'aquest lloc.</p>',
   'modal.save-retry.button-retry': 'Torna-ho a provar',

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -63,7 +63,7 @@ export default {
   'index.features.list.evaluation': 'Du behältst den Überblick durch eine automatisch aktualisierte <strong>Übersicht der bevorzugten Antworten</strong>.',
   'index.link.have-a-try': 'probiere es jetzt aus',
   'index.hoster.title': 'Hoste dein eigenes Croodle:',
-  'index.hoster.text': 'Du musst diesem Croodle nicht vertrauen. Croodle ist freie Software und du kannst sie auf deinem eigenen Server installieren. Hierzu werden lediglich einige Megabyte Speicherplatz, PHP und SSL-Verschlüsselung benötigt. Die Software und Tipps zur Installation findest du auf <a href=\'https://github.com/jelhan/croodle\'>GitHub</a>.',
+  'index.hoster.text': 'Du musst diesem Croodle nicht vertrauen. Croodle ist freie Software und du kannst sie auf deinem eigenen Server installieren. Hierzu werden lediglich einige Megabyte Speicherplatz, PHP und SSL-Verschlüsselung benötigt. Die Software und Tipps zur Installation findest du auf {{{gitHubLink}}}.',
   'modal.save-retry.title': 'Speichern fehlgeschlagen.',
   'modal.save-retry.text': '<p>Deine Teilnahme konnte nicht gespeichert werden. Bitte prüfe deine Internetverbindung und versuche es anschließend erneut.</p><p>Sollte dies nicht helfen, kann ein kurzfristiges Ausfall des Servers schuld sein. Warte bitte einige Minuten bevor du es erneut versuchst. Du kannst die Seite so lange geöffnet lassen.</p><p>Sollten die Probleme anhalten, wende dich bitte an die Administratoren der Seite.</p>',
   'modal.save-retry.button-retry': 'erneut versuchen',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -63,7 +63,7 @@ export default {
   'index.features.list.evaluation': 'You keep an overview by an automatic actualized <strong>review of preferred answers</strong>.',
   'index.link.have-a-try': 'Try it now',
   'index.hoster.title': 'Host your own Croodle:',
-  'index.hoster.text': 'You don’t have to trust this Croodle. Croodle is a free software and you can install it on your own server. You only need some mega byte server space, PHP and SSL-encryption. The software and tips for installation are here: <a href=’https://github.com/jelhan/croodle’>GitHub</a>.',
+  'index.hoster.text': 'You don’t have to trust this Croodle. Croodle is a free software and you can install it on your own server. You only need some mega byte server space, PHP and SSL-encryption. The software and tips for installation are here: {{{gitHubLink}}}.',
   'modal.save-retry.title': 'Saving failed.',
   'modal.save-retry.text': '<p>Your attendance could not be saved. Please check your internet connection and try again.</p><p>If this doesn’t work, a short-term breakdown of the server could be the reason. Please wait a couple of minutes before trying again. You can leave the page open.</p><p>Please contact the site administrator if the problem persists.</p>',
   'modal.save-retry.button-retry': 'Try again',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -63,7 +63,7 @@ export default {
   'index.features.list.evaluation': 'Mantendrás el control mediante la <strong>revisión de las respuestas favoritas</strong>.',
   'index.link.have-a-try': 'pruebalo ahora',
   'index.hoster.title': 'Instala tu propio Croodle:',
-  'index.hoster.text': 'No tienes porque fiarte de este Croodle. Croodle es software libre y tu puedes instalarlo en tu propio servidor. Sólo unos pocos megas de espacio, PHP y encriptación-SSL. Puesde encontrar el software y ayuda en inglés para la instalación aquí <a href=\'https://github.com/jelhan/croodle\'>GitHub</a>.',
+  'index.hoster.text': 'No tienes porque fiarte de este Croodle. Croodle es software libre y tu puedes instalarlo en tu propio servidor. Sólo unos pocos megas de espacio, PHP y encriptación-SSL. Puesde encontrar el software y ayuda en inglés para la instalación aquí {{{gitHubLink}}}.',
   'modal.save-retry.title': 'Error al guardar',
   'modal.save-retry.text': '<p>Tu inscripción no pudo ser guardada. Por favor, comprueba tu conexión a internet e inténtalo de nuevo.</p><p>Si esto no ayuda, podría ser debido a un breve fallo en el servidor. Por favor, espera unos minutos e inténtalo de nuevo. Puedes esperar mientras la página se abre.</p><p>Si los problemas continúan, por favor, contacte al administrador de la página.</p>',
   'modal.save-retry.button-retry': 'Reintentar',

--- a/app/locales/it/translations.js
+++ b/app/locales/it/translations.js
@@ -63,7 +63,7 @@ export default {
   'index.features.list.evaluation': 'Avrai una panoramica attualizzata <strong>delle risposte preferite</strong>.',
   'index.link.have-a-try': 'Provalo subito',
   'index.hoster.title': 'Installa il tuo prorio Croodle:',
-  'index.hoster.text': 'Non devi per forza fidarti di questo Croodle. Croodle è un software libero che puoi installare in locale. Ti servono solamente pochi MB di spazio su disco, PHP, e supporto per SSL. Codice sorgente e documentazione sono disponibili qui:<a href=\'https://github.com/jelhan/croodle\'>GitHub</a>.',
+  'index.hoster.text': 'Non devi per forza fidarti di questo Croodle. Croodle è un software libero che puoi installare in locale. Ti servono solamente pochi MB di spazio su disco, PHP, e supporto per SSL. Codice sorgente e documentazione sono disponibili qui: {{{gitHubLink}}}.',
   'modal.save-retry.title': 'Salvataggio fallito.',
   'modal.save-retry.text': '<p> Impossibile salvare le tue risposte. Per favore controlla la tua connessione Internet e prova di nuovo.</p><p>Se questo non funziona, prova a riavviare il server, e attendi un minuto prima di tentare di nuovo. Puoi lasciare aperta la pagina.</p><p>Se i problemi persistono, contatta l\'amministratore di questo sito.</p>',
   'modal.save-retry.button-retry': 'Riprova',

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -34,7 +34,7 @@
     <div class="col-lg-5 offset-lg-1">
       <h3>{{t "index.hoster.title"}}</h3>
       <p>
-        {{t "index.hoster.text"}}
+        {{t "index.hoster.text" gitHubLink="<a href=\"https://github.com/jelhan/croodle\">GitHub</a>"}}
       </p>
     </div>
   </div>


### PR DESCRIPTION
The link to GitHub was broken for English locale due to using wrong quote type. This is now fixed by providing the link as a value to the translation.

Closes #353 