### PR TITLE
fix failing tests in Safari

### DIFF
--- a/tests/acceptance/view-poll-test.js
+++ b/tests/acceptance/view-poll-test.js
@@ -79,9 +79,12 @@ module('Acceptance | view poll', function(hooks) {
       expirationDate: moment().add(1, 'year'),
       isDateTime: true,
       options: [
-        { title: new Date('2015-12-12T11:11:00').toISOString() },
-        { title: new Date('2015-12-12T13:13:00').toISOString() },
-        { title: new Date('2016-01-01T11:11:00').toISOString() }
+        // need to parse the date with moment cause Safari's Date.parse()
+        // implementation treats a data-time string without explicit
+        // time zone as UTC rather than local time
+        { title: moment('2015-12-12T11:11:00').toISOString() },
+        { title: moment('2015-12-12T13:13:00').toISOString() },
+        { title: moment('2016-01-01T11:11:00').toISOString() }
       ],
       timezone
     });


### PR DESCRIPTION
Safari does not follow ES5 / ECMAScript 2015 date parsing rules. Per spec a date that has day + time but does not have an explicit time zone (e.g. "2019-01-01T00:00") should be parsed in local time. But Safari treats that one as UTC.