### PR TITLE
do not run tests on TravisCI which are also run as GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,15 @@
 ---
-language: php
+# TravisCI is only used for BrowserStack tests.
+# All other tests are run as GitHub Actions.
 
-matrix:
-  include:
-    - env: TEST="API"
-      php: 7.3
-    - env: TEST="API"
-      php: 7.2
-    - env: TEST="API"
-      php: 7.1
-    - env: TEST="EMBER"
-    - env: TEST="BROWSER"
-    - env: TEST="BUNDLESIZE"
+language: node_js
+node_js:
+  - "10"
 
-dist: trusty
-sudo: false
+dist: xenial
 
 addons:
   chrome: stable
-  firefox: latest-esr
 
 cache:
   yarn: true
@@ -27,44 +18,25 @@ env:
   global:
     - "BROWSERSTACK_USERNAME=jeldrikhanschke1"
     - "BROWSERSTACK_ACCESS_KEY=xaM9Uxurv2GyxFLKQXgj"
-
-before_install:
-  # use a recent node version if ember build is tested
-  - if [ $TEST = "EMBER" ] || [ $TEST = "BROWSER" ] || [ $TEST = "BUNDLESIZE" ]; then nvm install --lts; fi
-  # provide yarn if ember build is tested
-  - if [ $TEST = "EMBER" ] || [ $TEST = "BROWSER" ] || [ $TEST = "BUNDLESIZE" ]; then curl -o- -L https://yarnpkg.com/install.sh | bash; fi
-  - if [ $TEST = "EMBER" ] || [ $TEST = "BROWSER" ] || [ $TEST = "BUNDLESIZE" ]; then export PATH=$HOME/.yarn/bin:$PATH; fi
-
-install:
-  # install dependencies for client
-  - if [ $TEST = "EMBER" ] || [ $TEST = "BROWSER" ] || [ $TEST = "BUNDLESIZE" ]; then yarn install --no-interactive; fi
-  # install dependencies for api
-  - if [ $TEST = "API" ]; then cd api/ && composer install && cd ..; fi
-
-before_script:
-  # http://php.net/manual/de/ini.core.php#ini.always-populate-raw-post-data
-  - if [ $TEST = "API" ]; then echo 'always_populate_raw_post_data = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
-  # create a browser stack tunnel for cross-browser testing
-  - if [ $TEST = "BROWSER" ]; then node_modules/ember-cli/bin/ember browserstack:connect; fi
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
 
 branches:
   only:
     - master
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+before_script:
+  # create a browser stack tunnel for cross-browser testing
+  - node_modules/ember-cli/bin/ember browserstack:connect
+
 script:
-  # run frontend and integration tests
-  - if [ $TEST = "EMBER" ]; then yarn run lint:hbs; fi
-  - if [ $TEST = "EMBER" ]; then yarn run lint:js; fi
-  - if [ $TEST = "EMBER" ]; then yarn test; fi
-  # test that CSP headers in public/.htaccess are matching the ones configured in config/environment.js
-  - if [ $TEST = "EMBER" ]; then grep "`node_modules/ember-cli/bin/ember csp-headers --environment production --silent 2>&1 | sed 's/ $//'`" public/.htaccess || (echo "CSP headers in public/.htaccess does not match configuration" && exit 1); fi
-  # test against different browsers using sauce lab
-  - if [ $TEST = "BROWSER" ]; then yarn test --config-file testem.browserstack.js; fi
-  # test bundle size
-  - if [ $TEST = "BUNDLESIZE" ]; then yarn test:bundlesize; fi
-  # run api tests with composer
-  - if [ $TEST = "API" ]; then cd api/ && ./vendor/bin/codecept run && cd ..; fi
+  # run tests on BrowserStack
+  - yarn test --config-file testem.browserstack.js
 
 after_script:
   # destroy the sauce tunnel
-  - if [ $TEST = "BROWSER" ]; then node_modules/ember-cli/bin/ember browserstack:disconnect; fi
+  - inode_modules/ember-cli/bin/ember browserstack:disconnect


### PR DESCRIPTION
All tests except for BrowserStack tests were executed both on TravisCI and as GitHub Actions. As GitHub Actions has been proven to be stable we can remove duplicated tests now and only run BrowserStack tests on TravisCI. We should migrate them to GitHub Actions as well in a follow-up merge request to reduce complexity.

GitHub Actions were introduced in #320. In that pull request we decided to keep the existing CI pipeline on TravisCI until GitHub Actions have been proven to provide similar or better stability. I think that's what we have seen.

Faced some issues when trying to migrate the BrowserStack tests to GitHub Actions. Therefore they weren't migrated as part of #320. Details can be found in the discussion of that pull request.