### PR TITLE
let RenovateBot manage all depdendencies

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -2,34 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "ignoreDeps": [
-    "@ember/jquery",
-    "@ember/optional-features",
-    "broccoli-asset-rev",
-    "ember-ajax",
-    "ember-cli",
-    "ember-cli-app-version",
-    "ember-cli-babel",
-    "ember-cli-dependency-checker",
-    "ember-cli-eslint",
-    "ember-cli-htmlbars",
-    "ember-cli-htmlbars-inline-precompile",
-    "ember-cli-inject-live-reload",
-    "ember-cli-sri",
-    "ember-cli-template-lint",
-    "ember-cli-uglify",
-    "ember-data",
-    "ember-export-application-global",
-    "ember-load-initializers",
-    "ember-maybe-import-regenerator",
-    "ember-qunit",
-    "ember-resolver",
-    "ember-source",
-    "ember-welcome-page",
-    "eslint-plugin-ember",
-    "loader.js",
-    "qunit-dom"
-  ],
   "ignorePaths": [
     "lib/**"
   ],


### PR DESCRIPTION
RenovateBot was configured to ignore the dependencies, which are part of the default blueprint for Ember applications. Motivation was to update the Ember version, the blueprints and all default dependencies in one go.

Ember has gotten more flexible to support different combinations of dependency versions. Especially the latest versions are often working well together with recent versions of other dependencies.

In contrast updating all dependencies in a single step has been proven to be more difficult. E.g. we currently need to lock `ember-data` to an old version but can use latest versions of `ember-source` and `ember-cli`. Updating that two (and most of the other dependencies) do not require any change. But `eslint-plugin-ember` may introduce new rules in its recommended set, which require some refactoring. It's easier to handle all of that in small, independent tasks rather than in one big change.

Also Ember CLI Update was improved so that even `ember-cli` package and blueprints can be upgraded independently.

Long story short: I don't see any reason anymore to not manage all dependencies by RenovateBot.