### PR TITLE
refactor deprecated {{title}} to {{page-title}}

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <HeadLayout />
 
-{{title "Croodle"}}
+{{page-title "Croodle"}}
 
 <nav class="cr-navbar navbar navbar-dark">
   <h1 class="cr-logo">

--- a/app/templates/create.hbs
+++ b/app/templates/create.hbs
@@ -1,4 +1,4 @@
-{{title (t "create.title")}}
+{{page-title (t "create.title")}}
 
 <BsButtonGroup @justified={{true}} class="cr-steps-top-nav form-steps">
   {{#each this.formSteps as |formStep|}}

--- a/app/templates/poll.hbs
+++ b/app/templates/poll.hbs
@@ -1,5 +1,5 @@
 {{#let @model as |poll|}}
-  {{title poll.title}}
+  {{page-title poll.title}}
 
   <div id="poll">
     <div class="row">


### PR DESCRIPTION
Ember-page-title has deprecated `{{title}}` in v5 and removed it in v6. `{{page-title}}` helper with same API should be used instead. This will unblock the upgrade in #437.