### PR TITLE
provide required credentials for BrowserStack

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -115,8 +115,8 @@ jobs:
       - name: 'BrowserStack Env Setup'
         uses: 'browserstack/github-actions/setup-env@master'
         with:
-          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
-          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          username: 'jeldrikhanschke1'
+          access-key: 'xaM9Uxurv2GyxFLKQXgj'
       - name: 'Start BrowserStackLocal Tunnel'
         uses: 'browserstack/github-actions/setup-local@master'
         with:


### PR DESCRIPTION
GitHub Secrets are not available in GitHub Action triggered by pull request created from fork. But we want to run BrowserStack based tests for them as well. Adding the credentials as clear text again as it was the case before #467.