### PR TITLE
can not set type attribute using splattatributes

### DIFF
--- a/app/templates/components/next-button.hbs
+++ b/app/templates/components/next-button.hbs
@@ -1,7 +1,7 @@
 <BsButton
+  @buttonType="submit"
   @type="primary"
   class="cr-steps-bottom-nav__button cr-steps-bottom-nav__next-button next"
-  type="submit"
   ...attributes
 >
   <span class="cr-steps-bottom-nav__label">

--- a/app/templates/components/save-button.hbs
+++ b/app/templates/components/save-button.hbs
@@ -1,7 +1,7 @@
 <BsButton
+  @buttonType="submit"
   @type="primary"
   class="cr-steps-bottom-nav__button cr-steps-bottom-nav__next-button next"
-  type="submit"
   ...attributes
 >
   <span class="cr-steps-bottom-nav__label">


### PR DESCRIPTION
Ember has a known bug, which breaks setting `type` attribute using splatattributes: https://github.com/emberjs/ember.js/issues/18232 It's fixed in Glimmer VM 0.68.0 but that one is not yet part of a stable release. It will very likely land in `ember-source@3.25.0`.

This is breaking the upgrade of Ember Bootstrap to v4: #433 

After the upgrade to Ember Bootstrap v4 we can refactor to use `submitButton` component yielded by `<BsForm>`:

```hbs
<BsForm as |form|>
  <form.submitButton>submit</form.submitButton>
</BsForm>
```