### PR TITLE
pin node version using volta

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Due to security reasons you should have TLS encryption enabled and provide a val
 
 Production builds are provided as github [release assets](https://github.com/jelhan/croodle/releases).
 
-If you like to build yourself you have to install [yarn](https://yarnpkg.com/), [ember-cli](http://www.ember-cli.com/) and [composer](https://getcomposer.org/) before.
+If you like to build yourself you have to install [node](https://nodejs.org/), [yarn](https://yarnpkg.com/), [ember-cli](http://www.ember-cli.com/) and [composer](https://getcomposer.org/) before. It's recommended using [volta](https://volta.sh/) to ensure a compatible and tested node version is used.
 
 ```shell
 git clone git@github.com:jelhan/croodle.git

--- a/package.json
+++ b/package.json
@@ -116,5 +116,8 @@
       "i18n": ":abc: Internalization",
       "internal": ":house: Internal"
     }
+  },
+  "volta": {
+    "node": "12.22.12"
   }
 }


### PR DESCRIPTION
Build is failing with recent node versions. Pinning to an old node version (12) using [Volta](https://volta.sh/) to reduce churn.