### PR TITLE
add instructions running API using Docker for development purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,27 @@ If source files are changing, a rebuild and reload is triggered.
 By default Croodle uses an api mock in development. Since that one
 does not persist records all polls are gone after a reload.
 
-If you like to test against the real API, run api via php built-in web
-server: `php -S 127.0.0.1:8080 -t dist/`
+If you like to test against the real API, you could
+
+1. run the API using php built-in web server locally if having a
+   compatible version of PHP installed:
+
+   ```sh
+   php -S 127.0.0.1:8080 -t dist/
+   ```
+
+   or
+
+2. use Docker. A Dockerfile to build a development container of
+   Croodle's API is provided in `api/` folder. It exposes the API
+   at port 8080 using PHP's built-in web server.
+
+   ```sh
+   cd api
+   docker build --tag croodle-api .
+   docker run --rm -t -p 8080:8080 croodle-api
+   ``` 
+
 Afterwards start ember-cli development server using `--proxy` option:
 `ember server --proxy http://127.0.0.1:8080`.
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:7.2
+
+COPY . /croodle/api
+
+WORKDIR /root
+
+RUN curl -sS https://getcomposer.org/installer -o composer-setup.php && \
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+
+RUN apt update && \
+    apt install -y libzip-dev zip && \
+    docker-php-ext-install zip
+
+WORKDIR /croodle
+
+RUN cd /croodle/api && \
+    composer install
+
+RUN mkdir /croodle/data
+
+CMD php -S 0.0.0.0:8080


### PR DESCRIPTION
Ease development of fronted if not having PHP 7.2 installed on local machine.