### PR TITLE
ensure moment-timezone has data for current and next year

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-mirage": "^2.0.0",
-    "ember-cli-moment-shim": "^3.7.1",
+    "ember-cli-moment-shim": "jelhan/ember-cli-moment-shim#6eabccf0bee2a3840c3024c5d526bc9c349fa13f",
     "ember-cli-page-object": "^1.11.0",
     "ember-cli-sass": "^10.0.0",
     "ember-cli-sri": "^2.1.1",
@@ -105,7 +105,8 @@
     ]
   },
   "resolutions": {
-    "chart.js": "~2.6.0"
+    "chart.js": "~2.6.0",
+    "ember-get-config": "0.3.0"
   },
   "changelog": {
     "labels": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6513,10 +6513,9 @@ ember-cli-mirage@^2.0.0:
     lodash-es "^4.17.11"
     miragejs "^0.1.31"
 
-ember-cli-moment-shim@^3.7.1:
+ember-cli-moment-shim@^3.7.1, ember-cli-moment-shim@jelhan/ember-cli-moment-shim#6eabccf0bee2a3840c3024c5d526bc9c349fa13f:
   version "3.8.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.8.0.tgz#dc61bbac9dce4963394e60dd42726d4ba38e2bc1"
-  integrity sha512-dN5ImjrjZevEqB7xhwFXaPWwxdKGSFiR1kqy9gDVB+A5EGnhCL1uveKugcyJE/MICVhXUAHBUu6G2LFWEPF2YA==
+  resolved "https://codeload.github.com/jelhan/ember-cli-moment-shim/tar.gz/6eabccf0bee2a3840c3024c5d526bc9c349fa13f"
   dependencies:
     broccoli-funnel "^2.0.0"
     broccoli-merge-trees "^2.0.0"
@@ -6525,10 +6524,10 @@ ember-cli-moment-shim@^3.7.1:
     chalk "^1.1.3"
     ember-cli-babel "^7.1.2"
     ember-cli-import-polyfill "^0.2.0"
-    ember-get-config ""
+    ember-get-config "^1.0.0"
     lodash.defaults "^4.2.0"
     moment "^2.19.3"
-    moment-timezone "^0.5.13"
+    moment-timezone "^0.5.43"
 
 ember-cli-node-assets@^0.2.2:
   version "0.2.2"
@@ -6970,7 +6969,7 @@ ember-focus-trap@^0.3.2:
     ember-modifier-manager-polyfill "^1.1.0"
     focus-trap "^5.0.1"
 
-ember-get-config@, "ember-get-config@^0.2.4 || ^0.3.0":
+ember-get-config@0.3.0, "ember-get-config@^0.2.4 || ^0.3.0", ember-get-config@^1.0.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.3.0.tgz#a73a1a87b48d9dde4c66a0e52ed5260b8a48cfbd"
   integrity sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==
@@ -11085,22 +11084,17 @@ mktemp@~0.4.0:
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
   integrity sha1-bQUVYRyKjITkhKogABKbmOmB/ws=
 
-moment-timezone@^0.5.13:
-  version "0.5.31"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"
-  integrity sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==
+moment-timezone@^0.5.43:
+  version "0.5.43"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
+  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
   dependencies:
-    moment ">= 2.9.0"
+    moment "^2.29.4"
 
-"moment@>= 2.9.0", moment@^2.19.3:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
-moment@^2.10.6:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+moment@2.29.4, moment@^2.10.6, moment@^2.19.3, moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 morgan@^1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Timezone information included in the build only captured 2012-2022. Therefore time has been wrong in some cases for every date in 2023 and later.

This PR fixes the bug by

1. updating `moment-timezone` to most recent release and
2. using a fork of `ember-cli-moment-shim` to pull in the correct version.

None of this is a long-term solution. In mid- to long-term moment should be dropped and JavaScript's [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) API used instead.

Fixes #569 