### PR TITLE
Fix executing tests with Firefox in CI

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -90,8 +90,10 @@ jobs:
           node-version: '14.x'
       - name: Install node modules
         run: yarn install
-      - name: Install Firefox
-        run: sudo apt-get install firefox
+      - name: Setup firefox
+        uses: browser-actions/setup-firefox@latest
+        with:
+          firefox-version: 102.0.1
       - name: Build with test environment
         env:
           CI: true


### PR DESCRIPTION
Downgrading Firefox to an older version as done in ember-source repository: https://github.com/emberjs/ember.js/blob/3d43480ad228c9b460922eff1c70984c93b391b2/.github/workflows/ci.yml#L267C1-L270C35