### PR TITLE
RenovateBot should update dependencies within ranges once per week

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -1,9 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ],
-  "ignorePaths": [
-    "lib/**"
-  ],
-  "rangeStrategy": "update-lockfile"
-}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":maintainLockFilesWeekly",
+    ":preserveSemverRanges"
+  ],
+  "ignorePaths": [
+    "lib/**"
+  ],
+  "postUpdateOptions": ["yarnDedupeHighest"]
+}


### PR DESCRIPTION
This reduces the number of pull request to update dependencies created by RenovateBot. RenovateBot will create once per week a single PR to upgrade all dependencies within their configured ranges. Upgrades requiring to change the SemVer range are done in separate PRs. Additionally RenovateBot deduplicates the dependencies as a post-upgrade step.