### PR TITLE
refactor remaining components to @glimmer/component

### DIFF
--- a/app/components/inline-datepicker.js
+++ b/app/components/inline-datepicker.js
@@ -1,7 +1,0 @@
-import classic from 'ember-classic-decorator';
-import { tagName } from '@ember-decorators/component';
-import Component from '@ember/component';
-
-@classic
-@tagName('')
-export default class InlineDatepicker extends Component {}

--- a/app/components/language-select.hbs
+++ b/app/components/language-select.hbs
@@ -1,5 +1,7 @@
-{{#each-in this.locales as |localeKey localeName|}}
-  <option value={{localeKey}} selected={{eq localeKey this.currentLocale}}>
-    {{localeName}}
-  </option>
-{{/each-in}}
+<select class="language-select" {{on "change" this.handleChange}}>
+  {{#each-in this.locales as |localeKey localeName|}}
+    <option value={{localeKey}} selected={{eq localeKey this.currentLocale}}>
+      {{localeName}}
+    </option>
+  {{/each-in}}
+</select>

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -1,18 +1,11 @@
-import classic from 'ember-classic-decorator';
-import { classNames, tagName } from '@ember-decorators/component';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import Component from '@ember/component';
 import localesMeta from 'croodle/locales/meta';
+import { action } from '@ember/object';
 
-@classic
-@tagName('select')
-@classNames('language-select')
 export default class LanguageSelect extends Component {
-  @service
-  intl;
-
-  @service
-  powerCalendar;
+  @service intl;
+  @service powerCalendar;
 
   get currentLocale() {
     return this.intl.primaryLocale;
@@ -22,11 +15,12 @@ export default class LanguageSelect extends Component {
     return localesMeta;
   }
 
-  change(event) {
+  @action
+  handleChange(event) {
     const locale = event.target.value;
 
-    this.intl.set('locale', locale.includes('-') ? [locale, locale.split('-')[0]] : [locale]);
-    this.powerCalendar.set('locale', locale);
+    this.intl.locale = locale.includes('-') ? [locale, locale.split('-')[0]] : [locale];
+    this.powerCalendar.locale = locale;
 
     if (window.localStorage) {
       window.localStorage.setItem('locale', locale);

--- a/app/components/poll-evaluation-summary.hbs
+++ b/app/components/poll-evaluation-summary.hbs
@@ -1,48 +1,50 @@
-<h2>
-  {{t "poll.evaluation.label"}}
-</h2>
+<div class="evaluation-summary">
+  <h2>
+    {{t "poll.evaluation.label"}}
+  </h2>
 
-<p class="participants">
-  {{t "poll.evaluation.participants" count=@poll.users.length}}
-</p>
+  <p class="participants">
+    {{t "poll.evaluation.participants" count=@poll.users.length}}
+  </p>
 
-<p class="best-options">
-  {{#if @poll.isFindADate}}
+  <p class="best-options">
+    {{#if @poll.isFindADate}}
+      {{t
+        "poll.evaluation.bestOption.label.findADate"
+        count=this.bestOptions.length
+      }}
+    {{else}}
+      {{t
+        "poll.evaluation.bestOption.label.makeAPoll"
+        count=this.bestOptions.length
+      }}
+    {{/if}}
+
+    {{#if (get this.bestOptions.length 1)}}
+      <ul>
+        {{#each this.bestOptions as |evaluationBestOption|}}
+          <li>
+            <PollEvaluationSummaryOption
+              @evaluationBestOption={{evaluationBestOption}}
+              @isFindADate={{@poll.isFindADate}}
+              @timeZone={{@timeZone}}
+            />
+          </li>
+        {{/each}}
+      </ul>
+    {{else}}
+      <PollEvaluationSummaryOption
+        @evaluationBestOption={{this.bestOptions.firstObject}}
+        @isFindADate={{@poll.isFindADate}}
+        @timeZone={{@timeZone}}
+      />
+    {{/if}}
+  </p>
+
+  <p class="last-participation">
     {{t
-      "poll.evaluation.bestOption.label.findADate"
-      count=this.bestOptions.length
+      "poll.evaluation.lastParticipation"
+      ago=(format-date-relative this.lastParticipationAt)
     }}
-  {{else}}
-    {{t
-      "poll.evaluation.bestOption.label.makeAPoll"
-      count=this.bestOptions.length
-    }}
-  {{/if}}
-
-  {{#if (get this.bestOptions.length 1)}}
-    <ul>
-      {{#each this.bestOptions as |evaluationBestOption|}}
-        <li>
-          <PollEvaluationSummaryOption
-            @evaluationBestOption={{evaluationBestOption}}
-            @isFindADate={{@poll.isFindADate}}
-            @timeZone={{@timeZone}}
-          />
-        </li>
-      {{/each}}
-    </ul>
-  {{else}}
-    <PollEvaluationSummaryOption
-      @evaluationBestOption={{this.bestOptions.firstObject}}
-      @isFindADate={{@poll.isFindADate}}
-      @timeZone={{@timeZone}}
-    />
-  {{/if}}
-</p>
-
-<p class="last-participation">
-  {{t
-    "poll.evaluation.lastParticipation"
-    ago=(format-date-relative this.lastParticipationAt)
-  }}
-</p>
+  </p>
+</div>

--- a/app/components/poll-evaluation-summary.js
+++ b/app/components/poll-evaluation-summary.js
@@ -1,15 +1,12 @@
-import Component from '@ember/component';
-import { classNames } from '@ember-decorators/component';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { copy } from '@ember/object/internals';
 
-@classNames('evaluation-summary')
 export default class PollEvaluationSummary extends Component {
-  @service
-  intl;
+  @service intl;
 
   get bestOptions() {
-    const { poll } = this;
+    const { poll } = this.args;
     const { isFreeText, options, users } = poll;
 
     // can not evaluate answer type free text
@@ -74,7 +71,7 @@ export default class PollEvaluationSummary extends Component {
   }
 
   get lastParticipationAt() {
-    const { users } = this.poll;
+    const { users } = this.args.poll;
 
     let lastParticipationAt = null;
 


### PR DESCRIPTION
` @ember/component` are an outdated patter in Ember. `@glimmer/component` are not only the future but also easier to understand. Another small step towards better maintainability of the code base.