### PR TITLE
remove unused named outlet

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,20 +1,20 @@
-{{page-title "Croodle"}}
+{{page-title 'Croodle'}}
 
-<nav class="cr-navbar navbar navbar-dark">
-  <h1 class="cr-logo">
-    <LinkTo @route="index" class="navbar-brand">
+<nav class='cr-navbar navbar navbar-dark'>
+  <h1 class='cr-logo'>
+    <LinkTo @route='index' class='navbar-brand'>
       Croodle
     </LinkTo>
   </h1>
-  <div class="collapse" id="headerNavbar">
-    <form class="form-inline my-2 my-lg-0">
-      <LanguageSelect class="custom-select custom-select-sm" />
+  <div class='collapse' id='headerNavbar'>
+    <form class='form-inline my-2 my-lg-0'>
+      <LanguageSelect class='custom-select custom-select-sm' />
     </form>
   </div>
 </nav>
 
-<main class="container cr-main">
-  <div id="messages">
+<main class='container cr-main'>
+  <div id='messages'>
     {{#each this.flashMessages.queue as |flash|}}
       <FlashMessage @flash={{flash}}>
         {{t flash.message}}
@@ -24,5 +24,3 @@
 
   {{outlet}}
 </main>
-
-{{outlet "modal"}}


### PR DESCRIPTION
This dates back to 2015 (https://github.com/jelhan/croodle/commit/f0a09d9aeed9b328896e8ce0629f982c46e70102) and isn't used anymore since a long time. Named outlets have been deprecated in Ember 3.x and removed in Ember 4.0, which brought it to my attention.