### PR TITLE
fix broken live reload due to upgrade to Ember CLI v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-cli-deprecation-workflow": "^2.0.0",
     "ember-cli-flash": "^4.0.0",
     "ember-cli-htmlbars": "^6.3.0",
-    "ember-cli-inject-live-reload": "^2.1.0",
+    "ember-cli-inject-live-reload": "https://gitpkg.now.sh/jelhan/ember-cli-inject-live-reload/lib?39c289e20aa5bd398da6f480e416e53b2973ef9c",
     "ember-cli-mirage": "^3.0.0",
     "ember-cli-page-object": "^2.0.0",
     "ember-cli-sass": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5784,10 +5784,9 @@ ember-cli-htmlbars@^6.0.0, ember-cli-htmlbars@^6.0.1, ember-cli-htmlbars@^6.1.0,
     silent-error "^1.1.1"
     walk-sync "^2.2.0"
 
-ember-cli-inject-live-reload@^2.1.0:
+"ember-cli-inject-live-reload@https://gitpkg.now.sh/jelhan/ember-cli-inject-live-reload/lib?39c289e20aa5bd398da6f480e416e53b2973ef9c":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-2.1.0.tgz#ef63c733c133024d5726405a3c247fa12e88a385"
-  integrity sha512-YV5wYRD5PJHmxaxaJt18u6LE6Y+wo455BnmcpN+hGNlChy2piM9/GMvYgTAz/8Vin8RJ5KekqP/w/NEaRndc/A==
+  resolved "https://gitpkg.now.sh/jelhan/ember-cli-inject-live-reload/lib?39c289e20aa5bd398da6f480e416e53b2973ef9c#9450289441d8e8c9e55db702462fcedf741e18b8"
   dependencies:
     clean-base-url "^1.0.0"
     ember-cli-version-checker "^3.1.3"


### PR DESCRIPTION
This uses the fix proposed upstream here: https://github.com/ember-cli/ember-cli-inject-live-reload/pull/196