### PR TITLE
try fixing RenovateBot by removing postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,5 @@
   ],
   "ignorePaths": [
     "lib/**"
-  ],
-  "postUpdateOptions": ["npmDedupe"]
+  ]
 }


### PR DESCRIPTION
RenovateBot stopped working. Looking at the timing it may be caused by switching to NPM in #696. Removing `postUpdateOptions` to see if the new `npmDedupe` option may causes the issue.