### PR TITLE
RebovateBot should dedupe deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,8 @@
   ],
   "ignorePaths": [
     "lib/**"
+  ],
+  "postUpdateOptions": [
+    "npmDedupe"
   ]
 }


### PR DESCRIPTION
This hopefully works again reliable with the optimizations pushed to RebovateBot for deduplicating NPM dependencies.