### PR TITLE
Disable NPM dedupe RenovateBot option again

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,5 @@
   ],
   "ignorePaths": [
     "lib/**"
-  ],
-  "postUpdateOptions": [
-    "npmDedupe"
   ]
 }


### PR DESCRIPTION
Reverts #718. It seems that RenovateBot stopped working after I had enabled it.