### PR TITLE
pin typescript to minor version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "stylelint-config-standard-scss": "^11.0.0",
         "stylelint-prettier": "^4.0.2",
         "tracked-built-ins": "^3.3.0",
-        "typescript": "^5.2.2",
+        "typescript": "~5.2.2",
         "webpack": "^5.88.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "stylelint-config-standard-scss": "^11.0.0",
     "stylelint-prettier": "^4.0.2",
     "tracked-built-ins": "^3.3.0",
-    "typescript": "^5.2.2",
+    "typescript": "~5.2.2",
     "webpack": "^5.88.2"
   },
   "overrides": {


### PR DESCRIPTION
Upgrades of TypeScript minor version cause type errors. Package lock file maintenance isn't working. Pinning it to minor version as TypeScript team does not follow SemVer.

[skip ci]