### PR TITLE
RenovateBot should merge SemVer safe upgrades automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    ":maintainLockFilesWeekly",
+    "config:js-app",
+    ":automergeBranch",
+    ":automergeStableNonMajor",
+    ":maintainLockFilesWeekly"
   ],
   "ignorePaths": [
     "lib/**"


### PR DESCRIPTION
Let's reduce manual work and let RenovatBot merge any upgrade, which is not a major version, automatically. E.g. #737 and #736 should be merged automatically rather than needing manual attention.