### PR TITLE
run CI on RenovateBot features branch to enable automerging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - renovate/*
   pull_request:
 
 jobs:


### PR DESCRIPTION
This has the trade-off of running CI twice for every RenovateBot upgrade with a PR. But I don't know any other way to solve it.