### PR TITLE
RenovateBot should upgrade all Glint packages together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,10 @@
         "ember-power-calendar",
         "ember-power-calendar-luxon"
       ]
+    },
+    {
+      "groupName": "GLint",
+      "matchPackageNames": ["@glint/*"]
     }
   ]
 }


### PR DESCRIPTION
The `@glint/*` packages must be updated together. Or at least in a specific order. Otherwise the updates fail due to peer dependency resolution issues. See #1025 as a recent example.