### PR TITLE
expiration warning should span entire width

### DIFF
--- a/client/app/components/poll.hbs
+++ b/client/app/components/poll.hbs
@@ -36,7 +36,7 @@
 
   {{#if this.showExpirationWarning}}
     <div class="row">
-      <div class="col-xs-12">
+      <div class="col-12">
         <BsAlert @type="warning" class="expiration-warning">
           {{t
             "poll.expiration-date-warning"


### PR DESCRIPTION
## Before

<img width="2262" height="687" alt="image" src="https://github.com/user-attachments/assets/4f937fb1-c50b-4d59-b9a0-a72da0e77980" />

## After

<img width="2291" height="679" alt="image" src="https://github.com/user-attachments/assets/d14480ca-b636-423b-a8ac-a67e0069daac" />
