### PR TITLE
poll expiration setting dropdown does not show current value

### DIFF
--- a/client/app/components/create-settings.ts
+++ b/client/app/components/create-settings.ts
@@ -147,7 +147,11 @@ export default class CreateSettingsComponent extends Component<CreateSettingsSig
           anonymousUser,
           answerType,
           description,
-          expirationDate: expirationDuration ? DateTime.local().plus(Duration.fromISO(expirationDuration)).toISO() : '',
+          expirationDate: expirationDuration
+            ? DateTime.local()
+                .plus(Duration.fromISO(expirationDuration))
+                .toISO()
+            : '',
           forceAnswer,
           options: options.map((option) => {
             return { title: option };

--- a/client/app/routes/create.ts
+++ b/client/app/routes/create.ts
@@ -10,7 +10,8 @@ class PollData {
   @tracked anonymousUser: boolean = false;
   @tracked answerType: AnswerType = 'YesNo';
   @tracked description: string = '';
-  @tracked expirationDuration: 'P7D' | 'P1M' | 'P3M' | 'P6M' | 'P1Y' | '' = 'P3M';
+  @tracked expirationDuration: 'P7D' | 'P1M' | 'P3M' | 'P6M' | 'P1Y' | '' =
+    'P3M';
   @tracked forceAnswer: boolean = true;
   @tracked freetextOptions: TrackedSet<string> = new TrackedSet();
   @tracked dateOptions: TrackedSet<string> = new TrackedSet();

--- a/client/tests/acceptance/create-a-poll-test.js
+++ b/client/tests/acceptance/create-a-poll-test.js
@@ -814,7 +814,6 @@ module('Acceptance | create a poll', function (hooks) {
     await click('button[type="submit"]');
     assert.strictEqual(currentRouteName(), 'create.options');
 
-
     await pageCreateOptions.selectDates([
       new Date('2025-03-02'),
       new Date('2025-03-07'),
@@ -824,14 +823,26 @@ module('Acceptance | create a poll', function (hooks) {
 
     await click('button[type="submit"]');
     assert.strictEqual(currentRouteName(), 'create.settings');
-    assert.dom('.expiration-duration select').hasValue('P3M', 'poll expires in 3 months by default');
+    assert
+      .dom('.expiration-duration select')
+      .hasValue('P3M', 'poll expires in 3 months by default');
 
     await fillIn('.expiration-duration select', 'P7D');
-    assert.dom('.expiration-duration select').hasValue('P7D', 'expiration date reflects updated value after user input');
+    assert
+      .dom('.expiration-duration select')
+      .hasValue(
+        'P7D',
+        'expiration date reflects updated value after user input',
+      );
 
     await click('button[type="submit"]');
     assert.strictEqual(currentRouteName(), 'poll.participation');
-    assert.dom('.expirationDate').containsText('March 8, 2025', 'poll information reflect expiration date selected by user');
+    assert
+      .dom('.expirationDate')
+      .containsText(
+        'March 8, 2025',
+        'poll information reflect expiration date selected by user',
+      );
   });
 
   test('create a poll and use back button (find a date)', async function (assert) {


### PR DESCRIPTION
This bug was introduced due to refactoring which wasn't released yet. It is _not_ affecting any released version.